### PR TITLE
counter_culture_fix_counts not respecting deleted_at columns

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -74,6 +74,8 @@ module CounterCulture
           # we are only interested in the id and the count of related objects (that's this class itself)
           query = klass.select("#{klass.table_name}.id, COUNT(#{self.table_name}.id) AS count")
           query = query.group("#{klass.table_name}.id")
+          # respect the deleted_at column if it exists
+          query = query.where("#{self.table_name}.deleted_at IS NULL") if self.column_names.include?('deleted_at')
 
           column_names = hash[:column_names] || {nil => hash[:counter_cache_name]}
           raise ":column_names must be a Hash of conditions and column names" unless column_names.is_a?(Hash)


### PR DESCRIPTION
When inspecting some of the counter cache column counts on our dev machines, and then the query generated by counter_culture_fix_counts, we noticed it wasn't picking up our deleted_at columns for paranoid deletes.
