### PR TITLE
Fix touch option

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -288,7 +288,7 @@ module CounterCulture
           if options[:touch]
             current_time = current_time_from_proper_timezone
             timestamp_attributes_for_update_in_model.each do |timestamp_column|
-              updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:sql)}'"
+              updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:db)}'"
             end
           end
 


### PR DESCRIPTION
The `touch` option generate invalid datetime value for Mysql. According to ActiveRecord Quoting module is more correct use the `:db` instead `:sql` 

https://github.com/rails/rails/blob/2dc579baf4045fc6bcc38a2fe00d5fd19431201f/activerecord/test/cases/quoting_test.rb#L58

```
#<ActiveRecord::StatementInvalid: Mysql2::Error: Incorrect datetime value: '2014-01-03 13:26:49 UTC' for column 'updated_at' at row 1: UPDATE `project` SET `tasks_count` = COALESCE(`tasks_count`, 0) + 1, updated_at = '2014-01-03 13:26:49 UTC' WHERE `project`.`id` = 21>
```
