### PR TITLE
added delta by arbritary proc option

### DIFF
--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -25,14 +25,16 @@ describe "CounterCulture" do
     user.reviews_count.should == 0
     product.reviews_count.should == 0
     user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
 
-    user.reviews.create :user_id => user.id, :product_id => product.id, :approvals => 13
-    
+    user.reviews.create :user_id => user.id, :product_id => product.id, :approvals => 13, :review_text => '+17'
+
     user.reload
     product.reload
 
     user.reviews_count.should == 1
     user.review_approvals_count.should == 13
+    user.review_text_approvals_count.should == 17
     product.reviews_count.should == 1
   end
 
@@ -43,15 +45,17 @@ describe "CounterCulture" do
     user.reviews_count.should == 0
     product.reviews_count.should == 0
     user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 69
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 69, :review_text => '+51'
+
     user.reload
     product.reload
 
     user.reviews_count.should == 1
     product.reviews_count.should == 1
     user.review_approvals_count.should == 69
+    user.review_text_approvals_count.should == 51
 
     review.destroy
 
@@ -60,6 +64,7 @@ describe "CounterCulture" do
 
     user.reviews_count.should == 0
     user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
     product.reviews_count.should == 0
   end
 
@@ -73,9 +78,11 @@ describe "CounterCulture" do
     product.reviews_count.should == 0
     user1.review_approvals_count.should == 0
     user2.review_approvals_count.should == 0
+    user1.review_text_approvals_count.should == 0
+    user2.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user1.id, :product_id => product.id, :approvals => 42
-    
+    review = Review.create :user_id => user1.id, :product_id => product.id, :approvals => 42, :review_text => '+48'
+
     user1.reload
     user2.reload
     product.reload
@@ -85,6 +92,8 @@ describe "CounterCulture" do
     product.reviews_count.should == 1
     user1.review_approvals_count.should == 42
     user2.review_approvals_count.should == 0
+    user1.review_text_approvals_count.should == 48
+    user2.review_text_approvals_count.should == 0
 
     review.user = user2
     review.save!
@@ -98,9 +107,13 @@ describe "CounterCulture" do
     product.reviews_count.should == 1
     user1.review_approvals_count.should == 0
     user2.review_approvals_count.should == 42
+    user1.review_text_approvals_count.should == 0
+    user2.review_text_approvals_count.should == 48
 
     review.update_attribute(:approvals, 69)
     user2.reload.review_approvals_count.should == 69
+    review.update_attribute(:review_text, '+73')
+    user2.reload.review_text_approvals_count.should == 73
   end
 
   it "treats null delta column values as 0" do
@@ -130,15 +143,17 @@ describe "CounterCulture" do
     user.reviews_count.should == 0
     product.reviews_count.should == 0
     company.review_approvals_count.should == 0
+    company.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 314
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 314, :review_text => '+302'
+
     company.reload
     user.reload
     product.reload
 
     company.reviews_count.should == 1
     company.review_approvals_count.should == 314
+    company.review_text_approvals_count.should == 302
     user.reviews_count.should == 1
     product.reviews_count.should == 1
   end
@@ -152,9 +167,10 @@ describe "CounterCulture" do
     user.reviews_count.should == 0
     product.reviews_count.should == 0
     company.review_approvals_count.should == 0
+    company.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 314
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 314, :review_text => '+317'
+
     user.reload
     product.reload
     company.reload
@@ -163,6 +179,7 @@ describe "CounterCulture" do
     product.reviews_count.should == 1
     company.reviews_count.should == 1
     company.review_approvals_count.should == 314
+    company.review_text_approvals_count.should == 317
 
     review.destroy
 
@@ -174,6 +191,7 @@ describe "CounterCulture" do
     product.reviews_count.should == 0
     company.reviews_count.should == 0
     company.review_approvals_count.should == 0
+    company.review_text_approvals_count.should == 0
   end
 
   it "updates second-level counter cache on update" do
@@ -190,9 +208,11 @@ describe "CounterCulture" do
     product.reviews_count.should == 0
     company1.review_approvals_count.should == 0
     company2.review_approvals_count.should == 0
+    company1.review_text_approvals_count.should == 0
+    company2.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user1.id, :product_id => product.id, :approvals => 69
-    
+    review = Review.create :user_id => user1.id, :product_id => product.id, :approvals => 69, :review_text => '+85'
+
     user1.reload
     user2.reload
     company1.reload
@@ -206,6 +226,8 @@ describe "CounterCulture" do
     product.reviews_count.should == 1
     company1.review_approvals_count.should == 69
     company2.review_approvals_count.should == 0
+    company1.review_text_approvals_count.should == 85
+    company2.review_text_approvals_count.should == 0
 
     review.user = user2
     review.save!
@@ -223,9 +245,13 @@ describe "CounterCulture" do
     product.reviews_count.should == 1
     company1.review_approvals_count.should == 0
     company2.review_approvals_count.should == 69
+    company1.review_text_approvals_count.should == 0
+    company2.review_text_approvals_count.should == 85
 
     review.update_attribute(:approvals, 42)
     company2.reload.review_approvals_count.should == 42
+    review.update_attribute(:review_text, '+37')
+    company2.reload.review_text_approvals_count.should == 37
   end
 
   it "increments custom counter cache column on create" do
@@ -235,7 +261,7 @@ describe "CounterCulture" do
     product.rexiews_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id
-    
+
     product.reload
 
     product.rexiews_count.should == 1
@@ -248,7 +274,7 @@ describe "CounterCulture" do
     product.rexiews_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id
-    
+
     product.reload
 
     product.rexiews_count.should == 1
@@ -269,7 +295,7 @@ describe "CounterCulture" do
     product2.rexiews_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product1.id
-    
+
     product1.reload
     product2.reload
 
@@ -294,7 +320,7 @@ describe "CounterCulture" do
     user.tried_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id, :review_type => nil
-    
+
     user.reload
 
     user.using_count.should == 0
@@ -309,7 +335,7 @@ describe "CounterCulture" do
     user.tried_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id, :review_type => nil
-    
+
     product.reload
 
     user.using_count.should == 0
@@ -334,7 +360,7 @@ describe "CounterCulture" do
     user2.tried_count.should == 0
 
     review = Review.create :user_id => user1.id, :product_id => product.id, :review_type => nil
-    
+
     user1.reload
     user2.reload
 
@@ -354,64 +380,64 @@ describe "CounterCulture" do
     user2.using_count.should == 0
     user2.tried_count.should == 0
   end
-  
+
   describe "conditional counts on update" do
     let(:product) {Product.create!}
     let(:user) {User.create!}
-    
+
     it "should increment and decrement if changing column name" do
       user.using_count.should == 0
       user.tried_count.should == 0
-      
+
       review = Review.create :user_id => user.id, :product_id => product.id, :review_type => "using"
       user.reload
-      
+
       user.using_count.should == 1
       user.tried_count.should == 0
-      
+
       review.review_type = "tried"
       review.save!
-      
+
       user.reload
-      
+
       user.using_count.should == 0
       user.tried_count.should == 1
     end
-    
+
     it "should increment if changing from a nil column name" do
       user.using_count.should == 0
       user.tried_count.should == 0
-      
+
       review = Review.create :user_id => user.id, :product_id => product.id, :review_type => nil
       user.reload
-      
+
       user.using_count.should == 0
       user.tried_count.should == 0
-      
+
       review.review_type = "tried"
       review.save!
-      
+
       user.reload
-      
+
       user.using_count.should == 0
       user.tried_count.should == 1
     end
-    
+
     it "should decrement if changing column name to nil" do
       user.using_count.should == 0
       user.tried_count.should == 0
-      
+
       review = Review.create :user_id => user.id, :product_id => product.id, :review_type => "using"
       user.reload
-      
+
       user.using_count.should == 1
       user.tried_count.should == 0
-      
+
       review.review_type = nil
       review.save!
-      
+
       user.reload
-      
+
       user.using_count.should == 0
       user.tried_count.should == 0
     end
@@ -425,12 +451,13 @@ describe "CounterCulture" do
 
     industry.reviews_count.should == 0
     industry.review_approvals_count.should == 0
+    industry.review_text_approvals_count.should == 0
     company.reviews_count.should == 0
     user.reviews_count.should == 0
     product.reviews_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 42
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 42, :review_text => '+53'
+
     industry.reload
     company.reload
     user.reload
@@ -438,6 +465,7 @@ describe "CounterCulture" do
 
     industry.reviews_count.should == 1
     industry.review_approvals_count.should == 42
+    industry.review_text_approvals_count.should == 53
     company.reviews_count.should == 1
     user.reviews_count.should == 1
     product.reviews_count.should == 1
@@ -451,12 +479,13 @@ describe "CounterCulture" do
 
     industry.reviews_count.should == 0
     industry.review_approvals_count.should == 0
+    industry.review_text_approvals_count.should == 0
     company.reviews_count.should == 0
     user.reviews_count.should == 0
     product.reviews_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 42
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 42, :review_text => '+57'
+
     industry.reload
     company.reload
     user.reload
@@ -464,6 +493,7 @@ describe "CounterCulture" do
 
     industry.reviews_count.should == 1
     industry.review_approvals_count.should == 42
+    industry.review_text_approvals_count.should == 57
     company.reviews_count.should == 1
     user.reviews_count.should == 1
     product.reviews_count.should == 1
@@ -477,6 +507,7 @@ describe "CounterCulture" do
 
     industry.reviews_count.should == 0
     industry.review_approvals_count.should == 0
+    industry.review_text_approvals_count.should == 0
     company.reviews_count.should == 0
     user.reviews_count.should == 0
     product.reviews_count.should == 0
@@ -499,9 +530,11 @@ describe "CounterCulture" do
     user2.reviews_count.should == 0
     industry1.review_approvals_count.should == 0
     industry2.review_approvals_count.should == 0
+    industry1.review_text_approvals_count.should == 0
+    industry2.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user1.id, :product_id => product.id, :approvals => 42
-    
+    review = Review.create :user_id => user1.id, :product_id => product.id, :approvals => 42, :review_text => '+33'
+
     industry1.reload
     industry2.reload
     company1.reload
@@ -517,6 +550,8 @@ describe "CounterCulture" do
     user2.reviews_count.should == 0
     industry1.review_approvals_count.should == 42
     industry2.review_approvals_count.should == 0
+    industry1.review_text_approvals_count.should == 33
+    industry2.review_text_approvals_count.should == 0
 
     review.user = user2
     review.save!
@@ -536,9 +571,13 @@ describe "CounterCulture" do
     user2.reviews_count.should == 1
     industry1.review_approvals_count.should == 0
     industry2.review_approvals_count.should == 42
+    industry1.review_text_approvals_count.should == 0
+    industry2.review_text_approvals_count.should == 33
 
     review.update_attribute(:approvals, 69)
     industry2.reload.review_approvals_count.should == 69
+    review.update_attribute(:review_text, '-2')
+    industry2.reload.review_text_approvals_count.should == -2
   end
 
   it "increments third-level custom counter cache on create" do
@@ -550,7 +589,7 @@ describe "CounterCulture" do
     industry.rexiews_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id
-    
+
     industry.reload
 
     industry.rexiews_count.should == 1
@@ -565,7 +604,7 @@ describe "CounterCulture" do
     industry.rexiews_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id
-    
+
     industry.reload
     industry.rexiews_count.should == 1
 
@@ -588,7 +627,7 @@ describe "CounterCulture" do
     industry2.rexiews_count.should == 0
 
     review = Review.create :user_id => user1.id, :product_id => product.id
-    
+
     industry1.reload
     industry1.rexiews_count.should == 1
     industry2.reload
@@ -606,7 +645,7 @@ describe "CounterCulture" do
   it "increments dynamic counter cache on create" do
     user = User.create
     product = Product.create
-    
+
     user.using_count.should == 0
     user.tried_count.should == 0
 
@@ -628,7 +667,7 @@ describe "CounterCulture" do
   it "decrements dynamic counter cache on destroy" do
     user = User.create
     product = Product.create
-    
+
     user.using_count.should == 0
     user.tried_count.should == 0
 
@@ -671,14 +710,14 @@ describe "CounterCulture" do
     industry.tried_count.should == 0
 
     review_using = Review.create :user_id => user.id, :product_id => product.id, :review_type => 'using'
-    
+
     industry.reload
 
     industry.using_count.should == 1
     industry.tried_count.should == 0
 
     review_tried = Review.create :user_id => user.id, :product_id => product.id, :review_type => 'tried'
-    
+
     industry.reload
 
     industry.using_count.should == 1
@@ -695,14 +734,14 @@ describe "CounterCulture" do
     industry.tried_count.should == 0
 
     review_using = Review.create :user_id => user.id, :product_id => product.id, :review_type => 'using'
-    
+
     industry.reload
 
     industry.using_count.should == 1
     industry.tried_count.should == 0
 
     review_tried = Review.create :user_id => user.id, :product_id => product.id, :review_type => 'tried'
-    
+
     industry.reload
 
     industry.using_count.should == 1
@@ -738,7 +777,7 @@ describe "CounterCulture" do
     industry2.tried_count.should == 0
 
     review_using = Review.create :user_id => user1.id, :product_id => product.id, :review_type => 'using'
-    
+
     industry1.reload
     industry2.reload
 
@@ -748,7 +787,7 @@ describe "CounterCulture" do
     industry2.tried_count.should == 0
 
     review_tried = Review.create :user_id => user1.id, :product_id => product.id, :review_type => 'tried'
-    
+
     industry1.reload
     industry2.reload
 
@@ -783,7 +822,7 @@ describe "CounterCulture" do
   it "should overwrite foreign-key values on create" do
     3.times { Category.create }
     Category.all {|category| category.products_count.should == 0 }
-    
+
     product = Product.create :category_id => Category.first.id
     Category.all {|category| category.products_count.should == 1 }
   end
@@ -791,7 +830,7 @@ describe "CounterCulture" do
   it "should overwrite foreign-key values on destroy" do
     3.times { Category.create }
     Category.all {|category| category.products_count.should == 0 }
-    
+
     product = Product.create :category_id => Category.first.id
     Category.all {|category| category.products_count.should == 1 }
 
@@ -802,7 +841,7 @@ describe "CounterCulture" do
   it "should overwrite foreign-key values on destroy" do
     3.times { Category.create }
     Category.all {|category| category.products_count.should == 0 }
-    
+
     product = Product.create :category_id => Category.first.id
     Category.all {|category| category.products_count.should == 1 }
 
@@ -816,34 +855,40 @@ describe "CounterCulture" do
     user = User.create
     product = Product.create
 
-    user.reviews_count.should == 0
     product.reviews_count.should == 0
+    user.reviews_count.should == 0
     user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 69
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 69, :review_text => '+91'
+
     user.reload
     product.reload
 
-    user.reviews_count.should == 1
     product.reviews_count.should == 1
+    user.reviews_count.should == 1
     user.review_approvals_count.should == 69
+    user.review_text_approvals_count.should == 91
 
-    user.reviews_count = 0
     product.reviews_count = 2
+    user.reviews_count = 0
     user.review_approvals_count = 7
-    user.save!
+    user.review_text_approvals_count = 5
+
     product.save!
+    user.save!
 
     fixed = Review.counter_culture_fix_counts :skip_unsupported => true
-    fixed.length.should == 3
+    puts fixed
+    fixed.length.should == 4
 
-    user.reload
     product.reload
+    user.reload
 
-    user.reviews_count.should == 1
     product.reviews_count.should == 1
+    user.reviews_count.should == 1
     user.review_approvals_count.should == 69
+    user.review_text_approvals_count.should == 91
   end
 
   it "should fix where the count should go back to zero correctly" do
@@ -851,17 +896,22 @@ describe "CounterCulture" do
     product = Product.create
 
     user.reviews_count.should == 0
+    user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
 
     user.reviews_count = -1
+    user.review_approvals_count = -2
+    user.review_text_approvals_count = -3
     user.save!
 
     fixed = Review.counter_culture_fix_counts :skip_unsupported => true
-    fixed.length.should == 1
+    fixed.length.should == 3
 
     user.reload
 
     user.reviews_count.should == 0
-
+    user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
   end
 
   it "should fix a second-level counter cache correctly" do
@@ -873,9 +923,10 @@ describe "CounterCulture" do
     user.reviews_count.should == 0
     product.reviews_count.should == 0
     company.review_approvals_count.should == 0
+    company.review_text_approvals_count.should == 0
 
-    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 42
-    
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 42, :review_text => '+23'
+
     company.reload
     user.reload
     product.reload
@@ -884,9 +935,11 @@ describe "CounterCulture" do
     user.reviews_count.should == 1
     product.reviews_count.should == 1
     company.review_approvals_count.should == 42
+    company.review_text_approvals_count.should == 23
 
     company.reviews_count = 2
     company.review_approvals_count = 7
+    company.review_text_approvals_count = 7
     user.reviews_count = 3
     product.reviews_count = 4
     company.save!
@@ -902,6 +955,7 @@ describe "CounterCulture" do
     user.reviews_count.should == 1
     product.reviews_count.should == 1
     company.review_approvals_count.should == 42
+    company.review_text_approvals_count.should == 23
   end
 
   it "should fix a custom counter cache correctly" do
@@ -911,7 +965,7 @@ describe "CounterCulture" do
     product.rexiews_count.should == 0
 
     review = Review.create :user_id => user.id, :product_id => product.id
-    
+
     product.reload
 
     product.rexiews_count.should == 1
@@ -928,7 +982,7 @@ describe "CounterCulture" do
   it "should fix a dynamic counter cache correctly" do
     user = User.create
     product = Product.create
-    
+
     user.using_count.should == 0
     user.tried_count.should == 0
 
@@ -978,9 +1032,238 @@ describe "CounterCulture" do
     string_id.users_count.should == 123
 
     User.counter_culture_fix_counts
-    
+
     string_id.reload
     string_id.users_count.should == 2
+  end
+
+  it "should raise a good error message when calling fix_counts with no caches defined" do
+    expect { Category.counter_culture_fix_counts }.to raise_error "No counter cache defined on Category"
+  end
+
+  it "should correctly fix the counter caches with thousands of records" do
+    # first, clean up
+    SimpleDependent.delete_all
+    SimpleMain.delete_all
+
+    1000.times do |i|
+      main = SimpleMain.create
+      3.times { main.simple_dependents.create }
+    end
+
+    SimpleMain.find_each { |main| main.simple_dependents_count.should == 3 }
+
+    SimpleMain.order('random()').limit(50).update_all simple_dependents_count: 1
+    SimpleDependent.counter_culture_fix_counts :batch_size => 100
+
+    SimpleMain.find_each { |main| main.simple_dependents_count.should == 3 }
+  end
+
+  it "should correctly fix the counter caches when no dependent record exists for some of main records" do
+    # first, clean up
+    SimpleDependent.delete_all
+    SimpleMain.delete_all
+
+    1000.times do |i|
+      main = SimpleMain.create
+      (main.id % 4).times { main.simple_dependents.create }
+    end
+
+    SimpleMain.find_each { |main| main.simple_dependents_count.should == main.id % 4 }
+
+    SimpleMain.order('random()').limit(50).update_all simple_dependents_count: 1
+    SimpleDependent.counter_culture_fix_counts :batch_size => 100
+
+    SimpleMain.find_each { |main| main.simple_dependents_count.should == main.id % 4 }
+  end
+
+  # This test is for the delta case the last object is a special ending condition.
+  it "should correctly fix the last has many object with a belongs to and the following ones" do
+    user1 = User.create
+    user2 = User.create
+    user3 = User.create
+
+    user1.review_text_approvals_count.should == 0
+    # Last object with a belongs to:
+    user2.review_text_approvals_count.should == 0
+    # After the last. Count must be 0:
+    user3.review_text_approvals_count.should == 0
+
+    review1 = Review.create :user_id => user1.id, :review_text => '+1'
+    review2 = Review.create :user_id => user2.id, :review_text => '+2'
+
+    user1.reload
+    user2.reload
+    user3.reload
+
+    user1.review_text_approvals_count.should == 1
+    user2.review_text_approvals_count.should == 2
+    user3.review_text_approvals_count.should == 0
+
+    user1.review_text_approvals_count = 53
+    user2.review_text_approvals_count = 67
+    user3.review_text_approvals_count = 75
+
+    user1.save!
+    user2.save!
+    user3.save!
+
+    fixed = Review.counter_culture_fix_counts :skip_unsupported => true
+    fixed.length.should == 3
+
+    user1.reload
+    user2.reload
+    user3.reload
+
+    user1.review_text_approvals_count.should == 1
+    user2.review_text_approvals_count.should == 2
+    user3.review_text_approvals_count.should == 0
+  end
+
+  # This test is specially critical for `:delta`, since its counts may split across multiple batches.
+  it "should correctly fix counters when there are more belong to elements than batch_size" do
+    user = User.create
+    user.review_approvals_count.should == 0
+    user.review_text_approvals_count.should == 0
+
+    review1 = Review.create :user_id => user.id, :approvals => 1, :review_text => '+3'
+    review2 = Review.create :user_id => user.id, :approvals => 2, :review_text => '+4'
+
+    user.reload
+    user.review_approvals_count.should == 3
+    user.review_text_approvals_count.should == 7
+
+    user.review_approvals_count = -1
+    user.review_text_approvals_count = -1
+    user.save!
+
+    fixed = Review.counter_culture_fix_counts :skip_unsupported => true, :batch_size => 1
+    fixed.length.should == 2
+
+    user.reload
+    user.review_approvals_count.should == 3
+    user.review_text_approvals_count.should == 7
+  end
+
+  # This test is specially critical for `:delta`, since its counts may split across multiple batches.
+  it "should correctly fix counters when one has_many is split across multiple batches" do
+    user1 = User.create
+    user2 = User.create
+    user3 = User.create
+
+    user1.review_text_approvals_count.should == 0
+    user2.review_text_approvals_count.should == 0
+    user3.review_text_approvals_count.should == 0
+
+    review1   = Review.create :user_id => user1.id, :review_text => '+1'
+    review2   = Review.create :user_id => user2.id, :review_text => '+2'
+    review3_1 = Review.create :user_id => user3.id, :review_text => '+4'
+    # END OF FIRST BATCH. Next reviews falls on next batch.
+    review3_2 = Review.create :user_id => user3.id, :review_text => '+8'
+    review3_3 = Review.create :user_id => user3.id, :review_text => '+16'
+
+    user1.reload
+    user2.reload
+    user3.reload
+
+    user1.review_text_approvals_count.should == 1
+    user2.review_text_approvals_count.should == 2
+    user3.review_text_approvals_count.should == 28
+
+    user1.review_text_approvals_count = 57
+    user2.review_text_approvals_count = 62
+    user3.review_text_approvals_count = -4
+
+    user1.save!
+    user2.save!
+    user3.save!
+
+    fixed = Review.counter_culture_fix_counts :skip_unsupported => true, :batch_size => 3
+    fixed.length.should == 3
+
+    user1.reload
+    user2.reload
+    user3.reload
+
+    user1.review_text_approvals_count.should == 1
+    user2.review_text_approvals_count.should == 2
+    user3.review_text_approvals_count.should == 28
+  end
+
+  # This test is specially critical for `:delta`, since special code must take care of the zero case.
+  it "should correctly fix counters when one has_many in the middle of the batch has no belongs_to" do
+    user1 = User.create
+    user2 = User.create
+    user3 = User.create
+
+    user1.review_text_approvals_count.should == 0
+    # This user (has_many) will have no reviews (belongs_to):
+    user2.review_text_approvals_count.should == 0
+    user3.review_text_approvals_count.should == 0
+
+    review1 = Review.create :user_id => user1.id, :review_text => '+1'
+    review3 = Review.create :user_id => user3.id, :review_text => '+2'
+
+    user1.reload
+    user2.reload
+    user3.reload
+
+    user1.review_text_approvals_count.should == 1
+    user2.review_text_approvals_count.should == 0
+    user3.review_text_approvals_count.should == 2
+
+    user1.review_text_approvals_count = 57
+    user2.review_text_approvals_count = 62
+    user3.review_text_approvals_count = -4
+
+    user1.save!
+    user2.save!
+    user3.save!
+
+    fixed = Review.counter_culture_fix_counts :skip_unsupported => true, :batch_size => 3
+    fixed.length.should == 3
+
+    user1.reload
+    user2.reload
+    user3.reload
+
+    user1.review_text_approvals_count.should == 1
+    user2.review_text_approvals_count.should == 0
+    user3.review_text_approvals_count.should == 2
+  end
+
+  it "should correctly sum up float values" do
+    user = User.create
+
+    r1 = Review.create :user_id => user.id, :value => 3.4
+
+    user.reload
+    user.review_value_sum.round(1).should == 3.4
+
+    r2 = Review.create :user_id => user.id, :value => 7.2
+
+    user.reload
+    user.review_value_sum.round(1).should == 10.6
+
+    r3 = Review.create :user_id => user.id, :value => 5
+
+    user.reload
+    user.review_value_sum.round(1).should == 15.6
+
+    r2.destroy
+
+    user.reload
+    user.review_value_sum.round(1).should == 8.4
+
+    r3.destroy
+
+    user.reload
+    user.review_value_sum.round(1).should == 3.4
+
+    r1.destroy
+
+    user.reload
+    user.review_value_sum.round(1).should == 0
   end
 
   it "should work correctly for relationships with custom names" do
@@ -1043,80 +1326,6 @@ describe "CounterCulture" do
     string_id2.users_count.should == 0
   end
 
-  it "should raise a good error message when calling fix_counts with no caches defined" do
-    expect { Category.counter_culture_fix_counts }.to raise_error "No counter cache defined on Category"
-  end
-
-  it "should correctly fix the counter caches with thousands of records" do
-    # first, clean up
-    SimpleDependent.delete_all
-    SimpleMain.delete_all
-    
-    1000.times do |i|
-      main = SimpleMain.create
-      3.times { main.simple_dependents.create }
-    end
-
-    SimpleMain.find_each { |main| main.simple_dependents_count.should == 3 }
-
-    SimpleMain.order('random()').limit(50).update_all simple_dependents_count: 1
-    SimpleDependent.counter_culture_fix_counts :batch_size => 100
-
-    SimpleMain.find_each { |main| main.simple_dependents_count.should == 3 }
-  end
-
-  it "should correctly fix the counter caches when no dependent record exists for some of main records" do
-    # first, clean up
-    SimpleDependent.delete_all
-    SimpleMain.delete_all
-
-    1000.times do |i|
-      main = SimpleMain.create
-      (main.id % 4).times { main.simple_dependents.create }
-    end
-
-    SimpleMain.find_each { |main| main.simple_dependents_count.should == main.id % 4 }
-
-    SimpleMain.order('random()').limit(50).update_all simple_dependents_count: 1
-    SimpleDependent.counter_culture_fix_counts :batch_size => 100
-
-    SimpleMain.find_each { |main| main.simple_dependents_count.should == main.id % 4 }
-  end
-
-  it "should correctly sum up flaot values" do
-    user = User.create
-
-    r1 = Review.create :user_id => user.id, :value => 3.4
-
-    user.reload
-    user.review_value_sum.round(1).should == 3.4
-
-    r2 = Review.create :user_id => user.id, :value => 7.2
-
-    user.reload
-    user.review_value_sum.round(1).should == 10.6
-
-    r3 = Review.create :user_id => user.id, :value => 5
-
-    user.reload
-    user.review_value_sum.round(1).should == 15.6
-
-    r2.destroy
-
-    user.reload
-    user.review_value_sum.round(1).should == 8.4
-
-    r3.destroy
-
-    user.reload
-    user.review_value_sum.round(1).should == 3.4
-
-    r1.destroy
-
-    user.reload
-    user.review_value_sum.round(1).should == 0
-  end
-
   it "should update the timestamp if touch: true is set" do
     user = User.create
     product = Product.create
@@ -1130,18 +1339,18 @@ describe "CounterCulture" do
     user.created_at.to_i.should == user.updated_at.to_i
     product.created_at.to_i.should < product.updated_at.to_i
   end
-  
+
   describe "#previous_model" do
     let(:user){User.create :name => "John Smith", :manages_company_id => 1}
-    
+
     it "should return a copy of the original model" do
       user.name = "Joe Smith"
       user.manages_company_id = 2
       prev = user.send(:previous_model)
-      
+
       prev.name.should == "John Smith"
       prev.manages_company_id.should == 1
-      
+
       user.name.should =="Joe Smith"
       user.manages_company_id.should == 2
     end

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -2,18 +2,31 @@ class Review < ActiveRecord::Base
   belongs_to :user
   belongs_to :product
 
+  delta_proc = Proc.new {|review|
+      if review.review_text =~ /^([-+][0-9]+)/
+        $1.to_i
+      else
+        0
+      end
+  }
+
   counter_culture :product, :touch => true
   counter_culture :product, :column_name => 'rexiews_count'
   counter_culture :user
   counter_culture :user, :column_name => Proc.new { |model| model.review_type ? "#{model.review_type}_count" : nil }, :column_names => {"reviews.review_type = 'using'" => 'using_count', "reviews.review_type = 'tried'" => 'tried_count'}
   counter_culture :user, :column_name => 'review_approvals_count', :delta_column => 'approvals'
   counter_culture :user, :column_name => 'review_value_sum', :delta_column => 'value'
+  # If the product review text starts with `+-<number>`,
+  # then those approvals / reprovals are added to the 'review_text_aprovals_count' the user has made.
+  counter_culture :user, :column_name => 'review_text_approvals_count', :delta => delta_proc
   counter_culture [:user, :manages_company]
   counter_culture [:user, :manages_company], :column_name => 'review_approvals_count', :delta_column => 'approvals'
+  counter_culture [:user, :manages_company], :column_name => 'review_text_approvals_count', :delta => delta_proc
   counter_culture [:user, :manages_company, :industry]
   counter_culture [:user, :manages_company, :industry], :column_name => 'rexiews_count'
   counter_culture [:user, :manages_company, :industry], :column_name => Proc.new { |model| model.review_type ? "#{model.review_type}_count" : nil }
   counter_culture [:user, :manages_company, :industry], :column_name => 'review_approvals_count', :delta_column => 'approvals'
+  counter_culture [:user, :manages_company, :industry], :column_name => 'review_text_approvals_count', :delta => delta_proc
 
   after_create :update_some_text
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "tried_count",         :default => 0, :null => false
     t.integer  "managers_count",      :default => 0, :null => false
     t.integer  "review_approvals_count",      :default => 0, :null => false
+    t.integer  "review_text_approvals_count", :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -32,6 +33,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "using_count",         :default => 0, :null => false
     t.integer  "tried_count",         :default => 0, :null => false
     t.integer  "review_approvals_count",      :default => 0, :null => false
+    t.integer  "review_text_approvals_count", :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -54,6 +56,8 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.float    "value"
     t.datetime "created_at"
     t.datetime "updated_at"
+    # Used to test :delta.
+    t.string   "review_text"
   end
 
   create_table "users", :force => true do |t|
@@ -64,6 +68,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "using_count",         :default => 0, :null => false
     t.integer  "tried_count",         :default => 0, :null => false
     t.integer  "review_approvals_count",      :default => 0, :null => false
+    t.integer  "review_text_approvals_count",      :default => 0, :null => false
     t.string   "has_string_id_id"
     t.float    "review_value_sum",    :default => 0.0, :null => false
     t.datetime "created_at"


### PR DESCRIPTION
Fixes #38

What this does is well explained on the issue it closes, and on the new README section.

I feel it is logical to call the new option simply `:delta`, since it is analogous to `delta_column` but it does not deal with an specific column.

If anyone has a better name, please shoot.

**_update_counts_after_XXX**

Changes to the three `_update_counts_after_*` functions were trivial and should be easy to evaluate.

**counter_culture_fix_counts**

`counter_culture_fix_counts` was much less trivial and required some refactoring to keep things DRY.

Non `:delta` logic should still be intact.
- moved many method calls that do not depend on loop variables to outside of the loops
- moved all input validity and default value check to the very beginning of the method
- moved the final check logic into `fix_counts` private function
- renamed overly general variable names to make things easier to understand:
  - `records` => `records_to_fix`
  - `counts` => `updated_counts`
- used `find_in_batches` wherever possible, since it replaces at once `offset`, `limit` and the loop variable.
- made some comments on critical parts which were hard for me to understand

**tests**

All existing tests pass.

Added one `:delta` test for every existing `:delta_column` test.

Added a new test specific to `:delta` to check that sums are being made correctly across batches.

Put all functions that test `counter_culture_fix_counts` side by side.

**other changes**

Corrected a typo on a test name: "flaot" => "float".

Removed randomly placed trailing whitespaces.
