### PR TITLE
Remove hardcoded Gemfile version in instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Turbo-charged counter caches for your Rails app. Huge improvements over the Rail
 Add counter_culture to your Gemfile:
 
 ```ruby
-gem 'counter_culture', '~> 0.1.18'
+gem 'counter_culture'
 ```
 
 Then run ```bundle update ```


### PR DESCRIPTION
Seems like a bad idea to suggest a specific version in the installation 
instruction. People tend to follow these to the letter.
