### PR TITLE
Add support for rails enum

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -286,7 +286,12 @@ module CounterCulture
       if id_to_change && options[:counter_column]
         delta_magnitude = if options[:delta_column]
                             delta_attr_name = options[:was] ? "#{options[:delta_column]}_was" : options[:delta_column]
-                            self.send(delta_attr_name) || 0
+                            val = self.send(delta_attr_name)
+                            # check if value is a string. This can happen if the
+                            # delta_column is an enum
+                            val = val.is_a?(String) ? self[delta_attr_name.to_sym] : val
+
+                            val || 0
                           else
                             1
                           end

--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -289,8 +289,7 @@ module CounterCulture
                             val = self.send(delta_attr_name)
                             # check if value is a string. This can happen if the
                             # delta_column is an enum
-                            val = val.is_a?(String) ? self[delta_attr_name.to_sym] : val
-
+                            val = val.is_a?(String) ? self.class.send(options[:delta_column].pluralize)[val] : val
                             val || 0
                           else
                             1

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -141,6 +141,13 @@ describe "CounterCulture" do
     product.reload
 
     product.total_score.should == 2
+
+    review.score = "bad"
+    review.save
+
+    product.reload
+
+    product.total_score.should == 0
   end
 
   it "increments second-level counter cache on create" do

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -128,6 +128,21 @@ describe "CounterCulture" do
     product.reviews_count.should == 1
   end
 
+  it "uses enum value in delta column" do
+    user = User.create
+    product = Product.create
+
+    user.reviews_count.should == 0
+    product.reviews_count.should == 0
+    user.review_approvals_count.should == 0
+
+    review = Review.create :user_id => user.id, :product_id => product.id, :score => "great"
+
+    product.reload
+
+    product.total_score.should == 2
+  end
+
   it "increments second-level counter cache on create" do
     company = Company.create
     user = User.create :manages_company_id => company.id

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -15,7 +15,11 @@ class Review < ActiveRecord::Base
   counter_culture [:user, :manages_company, :industry], :column_name => Proc.new { |model| model.review_type ? "#{model.review_type}_count" : nil }
   counter_culture [:user, :manages_company, :industry], :column_name => 'review_approvals_count', :delta_column => 'approvals'
 
+  counter_culture :product, :column_name => 'total_score', :delta_column => 'score'
+
   after_create :update_some_text
+
+  enum score: [ :bad, :ok, :great ]
 
   def update_some_text
     update_attribute(:some_text, rand(36**12).to_s(36))

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "rexiews_count",       :default => 0, :null => false
     t.integer  "twitter_reviews_count",       :default => 0, :null => false
     t.integer  "category_id"
+    t.integer  "status"
+    t.integer  "total_score", :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -55,6 +57,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "user_id"
     t.integer  "product_id"
     t.integer  "approvals"
+    t.integer  "score", default: 1
     t.float    "value"
     t.string   "type"
     t.datetime "created_at"


### PR DESCRIPTION
This pull requests fixes issue #91.

It basically adds support for enum columns that define human readable names for internally used integer-values. I added a unit test to verify the correct behavior.