### PR TITLE
update readme about gem installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Turbo-charged counter caches for your Rails app. Huge improvements over the Rail
 Add counter_culture to your Gemfile:
 
 ```ruby
-gem 'counter_culture', '~> 0.1.23'
+gem 'counter_culture', '~> 0.1.33'
 ```
 
-Then run ```bundle update ```
+Then run `bundle install`
 
 ## Database Schema
 


### PR DESCRIPTION
Running `bundle update` would update all the gems in the application, better run just `bundle install` to install this particular gem.

I've also updated the version number, but I'd just leave it out entirely and use `gem 'counter_culture'` to install the latest version.