### PR TITLE
`Ambiguous column name id` fix

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -371,7 +371,8 @@ module CounterCulture
       if was
         first = relation.shift
         foreign_key_value = send("#{relation_foreign_key(first)}_was")
-        value = relation_klass(first).where("#{relation_primary_key(first)} = ?", foreign_key_value).first if foreign_key_value
+        klass = relation_klass(first)
+        value = klass.where("#{klass.table_name}.#{relation_primary_key(first)} = ?", foreign_key_value).first if foreign_key_value
       else
         value = self
       end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -397,8 +397,6 @@ describe "CounterCulture" do
   describe "conditional counts on update" do
     let(:product) {Product.create!}
     let(:user) {User.create!}
-    before(:all) {User.with_default_scope!}
-    after(:all) {User.without_default_scope!}
 
     it "should increment and decrement if changing column name" do
       user.using_count.should == 0
@@ -455,6 +453,27 @@ describe "CounterCulture" do
 
       user.using_count.should == 0
       user.tried_count.should == 0
+    end
+
+    it "should decrement if changing column name to nilwithout errors with default scope" do
+      User.with_default_scope do
+        user.using_count.should == 0
+        user.tried_count.should == 0
+
+        review = Review.create :user_id => user.id, :product_id => product.id, :review_type => "using"
+        user.reload
+
+        user.using_count.should == 1
+        user.tried_count.should == 0
+
+        review.review_type = nil
+        review.save!
+
+        user.reload
+
+        user.using_count.should == 0
+        user.tried_count.should == 0
+      end
     end
   end
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -455,7 +455,7 @@ describe "CounterCulture" do
       user.tried_count.should == 0
     end
 
-    it "should decrement if changing column name to nilwithout errors with default scope" do
+    it "should decrement if changing column name to nil without errors using default scope" do
       User.with_default_scope do
         user.using_count.should == 0
         user.tried_count.should == 0

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -397,6 +397,8 @@ describe "CounterCulture" do
   describe "conditional counts on update" do
     let(:product) {Product.create!}
     let(:user) {User.create!}
+    before(:all) {User.with_default_scope!}
+    after(:all) {User.without_default_scope!}
 
     it "should increment and decrement if changing column name" do
       user.using_count.should == 0

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -9,21 +9,21 @@ class User < ActiveRecord::Base
   has_many :reviews
   accepts_nested_attributes_for :reviews, :allow_destroy => true
 
-  default_scope {
-    if self._default_scope_enabled
+  default_scope do
+    if _default_scope_enabled
       joins("LEFT OUTER JOIN companies").uniq
     else
       all
     end
-  }
-
-  def self._default_scope_enabled
-    @_default_scope_enabled
   end
 
-  def self.with_default_scope
-    @_default_scope_enabled = true
-    yield
-    @_default_scope_enabled = false
+  class << self
+    attr_accessor :_default_scope_enabled
+
+    def with_default_scope
+      @_default_scope_enabled = true
+      yield
+      @_default_scope_enabled = false
+    end
   end
 end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -8,4 +8,12 @@ class User < ActiveRecord::Base
 
   has_many :reviews
   accepts_nested_attributes_for :reviews, :allow_destroy => true
+
+  def self.with_default_scope!
+    default_scope { joins("LEFT OUTER JOIN companies").uniq }
+  end
+
+  def self.without_default_scope!
+    default_scope { all }
+  end
 end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -9,11 +9,21 @@ class User < ActiveRecord::Base
   has_many :reviews
   accepts_nested_attributes_for :reviews, :allow_destroy => true
 
-  def self.with_default_scope!
-    default_scope { joins("LEFT OUTER JOIN companies").uniq }
+  default_scope {
+    if self._default_scope_enabled
+      joins("LEFT OUTER JOIN companies").uniq
+    else
+      all
+    end
+  }
+
+  def self._default_scope_enabled
+    @_default_scope_enabled
   end
 
-  def self.without_default_scope!
-    default_scope { all }
+  def self.with_default_scope
+    @_default_scope_enabled = true
+    yield
+    @_default_scope_enabled = false
   end
 end


### PR DESCRIPTION
If the counting table has a default_scope that contains a JOIN, counter_culture crashes with an error like this:
```
Ambiguous column name: id: SELECT  DISTINCT "users".* FROM "users" LEFT OUTER JOIN companies WHERE (id = 53)  ORDER BY "users"."id" ASC LIMIT 1
```

I added some tests and a fix. ;)