### PR TITLE
Implement specific increment/decrement counter methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Product.counter_culture_fix_counts :only => [[:subcategory, :category]]
 # :except and :only also accept arrays
 ```
 
-The ```counter_culture_fix_counts``` counts method uses batch processing of records to keep the memory consumption low. The default batch size is 1000 but is configurable like so
+The ```counter_culture_fix_counts``` method uses batch processing of records to keep the memory consumption low. The default batch size is 1000 but is configurable like so
 ```ruby
 # In an initializer
 CounterCulture.config.batch_size = 100

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -5,6 +5,10 @@ module CounterCulture
     attr_reader :model, :relation, *CONFIG_OPTIONS
 
     def initialize(model, relation, options)
+      if options[:column_names] && !options[:column_names].is_a?(Hash)
+        raise ":column_names must be a Hash of conditions and column names"
+      end
+
       @model = model
       @relation = relation.is_a?(Enumerable) ? relation : [relation]
 

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -26,10 +26,6 @@ module CounterCulture
           @after_commit_counter_cache = []
         end
 
-        if options[:column_names] && !options[:column_names].is_a?(Hash)
-          raise ":column_names must be a Hash of conditions and column names" 
-        end
-
         # add the counter to our collection
         @after_commit_counter_cache << Counter.new(self, relation, options)
       end

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -83,7 +83,7 @@ module CounterCulture
       _wrap_in_counter_culture_active do
         self.class.after_commit_counter_cache.each do |counter|
           # increment counter cache
-          counter.change_counter_cache(self, :increment => true)
+          counter.increment_counter_cache(self)
         end
       end
     end
@@ -93,7 +93,7 @@ module CounterCulture
       _wrap_in_counter_culture_active do
         self.class.after_commit_counter_cache.each do |counter|
           # decrement counter cache
-          counter.change_counter_cache(self, :increment => false)
+          counter.decrement_counter_cache(self)
         end
       end
     end
@@ -112,9 +112,9 @@ module CounterCulture
             counter_cache_name != counter_cache_name_was
 
             # increment the counter cache of the new value
-            counter.change_counter_cache(self, :increment => true, :counter_column => counter_cache_name)
+            counter.increment_counter_cache(self, :counter_column => counter_cache_name)
             # decrement the counter cache of the old value
-            counter.change_counter_cache(self, :increment => false, :was => true, :counter_column => counter_cache_name_was)
+            counter.decrement_counter_cache(self, :was => true, :counter_column => counter_cache_name_was)
           end
         end
       end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1371,23 +1371,6 @@ describe "CounterCulture" do
     categ.reload.posts_count.should == 1
   end
 
-  # TODO check that effect is tested rather than method directly
-  pending "#previous_model" do
-    let(:user){User.create :name => "John Smith", :manages_company_id => 1}
-
-    it "should return a copy of the original model" do
-      user.name = "Joe Smith"
-      user.manages_company_id = 2
-      prev = user.send(:previous_model)
-
-      prev.name.should == "John Smith"
-      prev.manages_company_id.should == 1
-
-      user.name.should =="Joe Smith"
-      user.manages_company_id.should == 2
-    end
-  end
-
   describe "self referential counter cache" do
     it "increments counter cache on create" do
       company = Company.create!
@@ -1420,6 +1403,26 @@ describe "CounterCulture" do
       fixed = Company.counter_culture_fix_counts
       fixed.length.should == 1
       company.reload.children_count.should == 1
+    end
+  end
+
+  describe "Counter" do
+    context "#previous_model" do
+      let(:user) {User.create :name => "John Smith", :manages_company_id => 1}
+
+      it "should return a copy of the original model" do
+        counter = User.after_commit_counter_cache.find { |c| c.relation == [:manages_company] }
+
+        user.name = "Joe Smith"
+        user.manages_company_id = 2
+        prev = counter.previous_model(user)
+
+        prev.name.should == "John Smith"
+        prev.manages_company_id.should == 1
+
+        user.name.should =="Joe Smith"
+        user.manages_company_id.should == 2
+      end
     end
   end
 end


### PR DESCRIPTION
I found the change_counter_cache is a little too open for a public method so I implemented AR-style increment/decrement methods which is more intentional and less error prone.

Also a typo fix, spec fix, and moved an option validation into the counter class in this PR as well, because I am crap at pull requests.