### PR TITLE
Added custom lambda support to :touch argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ By default, counter_culture does not update the timestamp of models when it upda
 
 This can be useful when you use Rails' caching mechanism and display a counter cache's value in the cached fragment.
 
+If you need to do something besides setting the default timestamp field to the current time, you can provide a hash of columns with lambdas:
+```ruby
+  counter_culture :category, :touch => { :category_cache_id => -> (product) { product.something(5) + 37 } }
+```
+
 ### Manually populating counter cache values
 
 You will sometimes want to populate counter-cache values from primary data. This is required when adding counter-caches to existing data. It is also recommended to run this regularly (at BestVendor, we run it once a week) to catch any incorrect values in the counter caches.

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -51,10 +51,16 @@ module CounterCulture
           # this updates the actual counter
           updates << "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{delta_magnitude}"
           # and here we update the timestamp, if so desired
-          if touch
+          if touch == true
             current_time = obj.send(:current_time_from_proper_timezone)
             obj.send(:timestamp_attributes_for_update_in_model).each do |timestamp_column|
               updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:db)}'"
+            end
+          elsif touch.is_a?(Hash)
+            touch.each do |col_name, touch_lambda|
+              quoted_touch_column = model.connection.quote_column_name(col_name.to_s)
+              value = touch_lambda.call(obj)
+              updates << "#{quoted_touch_column} = #{model.connection.quote(value)}"
             end
           end
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1305,6 +1305,16 @@ describe "CounterCulture" do
     product.created_at.to_i.should < product.updated_at.to_i
   end
 
+  it "should execute user code for update if :touch is set to a hash of lambdas" do
+    post = Post.new
+    post.save!
+    post.custom_touch_field.should be_nil
+
+    post_comment = PostComment.create!(:post_id => post.id)
+
+    post.reload.custom_touch_field.should == post_comment.id + 42
+  end
+
   it "should update counts correctly when creating using nested attributes" do
     user = User.create(:reviews_attributes => [{:some_text => 'abc'}, {:some_text => 'xyz'}])
     user.reload

--- a/spec/models/post_comment.rb
+++ b/spec/models/post_comment.rb
@@ -2,5 +2,5 @@ class PostComment < ActiveRecord::Base
   self.primary_key = :post_id
 
   belongs_to :post, :foreign_key => 'post_id'
-  counter_culture :post, :column_name => :comments_count
+  counter_culture :post, :column_name => :comments_count, touch: { custom_touch_field: -> (comment) { comment.id + 42 } }
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
 
   create_table "posts", :primary_key => "post_id", :force => true do |t|
     t.string   "title"
+    t.integer  "custom_touch_field", :default => nil
     t.integer  "fk_subcat_id", :default => nil
     t.integer  "comments_count", :null => false, :default => 0
     t.datetime "created_at", :null => false


### PR DESCRIPTION
This lets a user be more specific about how their cache invalidation fields work. For example, I needed this feature because my project uses random UUIDs rather than timestamps for cache expiration.