### PR TITLE
wrap fix_counts in transactions

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -53,14 +53,16 @@ module CounterCulture
 
         counts_query.group(full_primary_key(relation_class)).find_in_batches(batch_size: batch_size) do |records|
           # now iterate over all the models and see whether their counts are right
-          records.each do |record|
-            count = record.read_attribute('count') || 0
-            next if record.read_attribute(column_name) == count
+          ActiveRecord::Base.transaction do
+            records.each do |record|
+              count = record.read_attribute('count') || 0
+              next if record.read_attribute(column_name) == count
 
-            track_change(record, column_name, count)
+              track_change(record, column_name, count)
 
-            # use update_all because it's faster and because a fixed counter-cache shouldn't update the timestamp
-            relation_class.where(relation_class.primary_key => record.send(relation_class.primary_key)).update_all(column_name => count)
+              # use update_all because it's faster and because a fixed counter-cache shouldn't update the timestamp
+              relation_class.where(relation_class.primary_key => record.send(relation_class.primary_key)).update_all(column_name => count)
+            end
           end
         end
       end


### PR DESCRIPTION
We had to update over 10 mil records.  Wrapping each batch in #counter_culture_fix_counts in a transaction reduces each update query time from about 8.0ms to 0.3ms.  In total, saved us waiting >24 hours for the update to complete.

before:
![image](https://cloud.githubusercontent.com/assets/6203034/15459891/ef9533a4-2077-11e6-9831-3fe14dbcb814.png)

after:
![image](https://cloud.githubusercontent.com/assets/6203034/15459889/e732834c-2077-11e6-94df-693cd1f1e91d.png)
