### PR TITLE
Use `ActiveSupport.on_load` to hook into ActiveRecord

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -16,4 +16,6 @@ module CounterCulture
 end
 
 # extend ActiveRecord with our own code here
-::ActiveRecord::Base.send :include, CounterCulture::Extensions
+ActiveSupport.on_load(:active_record) do
+  include CounterCulture::Extensions
+end


### PR DESCRIPTION
There is a weird behaviour of config `belongs_to_required_by_default` on Rails 5.0.0.rc2 when gem is not playing nice with the rails hooks.

Related rails/rails/issues/23589