### PR TITLE
add required components of activesupport

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -1,5 +1,6 @@
 require 'after_commit_action'
 require 'active_support/concern'
+require 'active_support/lazy_load_hooks'
 
 require 'counter_culture/extensions'
 require 'counter_culture/counter'

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/module/attribute_accessors'
+
 module CounterCulture
   class Reconciler
     attr_reader :counter, :options, :changes


### PR DESCRIPTION
Hi.
I'd like to use this gem in my padrino project. Padrino hasn't depend on activesupport now, so these components should be `require`d .

What do you think?