### PR TITLE
Reduce counts of batch-testing specs (except in CI)

### DIFF
--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1250,20 +1250,24 @@ describe "CounterCulture" do
     expect { Category.counter_culture_fix_counts }.to raise_error "No counter cache defined on Category"
   end
 
+  MANY = CI_TEST_RUN ? 1000 : 20
+  A_FEW = CI_TEST_RUN ? 50:  10
+  A_BATCH = CI_TEST_RUN ? 100: 10
+
   it "should correctly fix the counter caches with thousands of records" do
     # first, clean up
     SimpleDependent.delete_all
     SimpleMain.delete_all
 
-    1000.times do |i|
+    MANY.times do |i|
       main = SimpleMain.create
       3.times { main.simple_dependents.create }
     end
 
     SimpleMain.find_each { |main| main.simple_dependents_count.should == 3 }
 
-    SimpleMain.order('random()').limit(50).update_all simple_dependents_count: 1
-    SimpleDependent.counter_culture_fix_counts :batch_size => 100
+    SimpleMain.order('random()').limit(A_FEW).update_all simple_dependents_count: 1
+    SimpleDependent.counter_culture_fix_counts :batch_size => A_BATCH
 
     SimpleMain.find_each { |main| main.simple_dependents_count.should == 3 }
   end
@@ -1273,15 +1277,15 @@ describe "CounterCulture" do
     ConditionalDependent.delete_all
     ConditionalMain.delete_all
 
-    1000.times do |i|
+    MANY.times do |i|
       main = ConditionalMain.create
       3.times { main.conditional_dependents.create(:condition => main.id % 2 == 0) }
     end
 
     ConditionalMain.find_each { |main| main.conditional_dependents_count.should == (main.id % 2 == 0 ? 3 : 0) }
 
-    ConditionalMain.order('random()').limit(50).update_all :conditional_dependents_count => 1
-    ConditionalDependent.counter_culture_fix_counts :batch_size => 100
+    ConditionalMain.order('random()').limit(A_FEW).update_all :conditional_dependents_count => 1
+    ConditionalDependent.counter_culture_fix_counts :batch_size => A_BATCH
 
     ConditionalMain.find_each { |main| main.conditional_dependents_count.should == (main.id % 2 == 0 ? 3 : 0) }
   end
@@ -1291,15 +1295,15 @@ describe "CounterCulture" do
     SimpleDependent.delete_all
     SimpleMain.delete_all
 
-    1000.times do |i|
+    MANY.times do |i|
       main = SimpleMain.create
       (main.id % 4).times { main.simple_dependents.create }
     end
 
     SimpleMain.find_each { |main| main.simple_dependents_count.should == main.id % 4 }
 
-    SimpleMain.order('random()').limit(50).update_all simple_dependents_count: 1
-    SimpleDependent.counter_culture_fix_counts :batch_size => 100
+    SimpleMain.order('random()').limit(A_FEW).update_all simple_dependents_count: 1
+    SimpleDependent.counter_culture_fix_counts :batch_size => A_BATCH
 
     SimpleMain.find_each { |main| main.simple_dependents_count.should == main.id % 4 }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'counter_culture'
 
 load "#{File.dirname(__FILE__)}/schema.rb"
 
+CI_TEST_RUN = (ENV['TRAVIS'] && 'TRAVIS') || (ENV['CIRCLECI'] && 'CIRCLE') || ENV["CI"] && 'CI'
+
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}


### PR DESCRIPTION
Have started working on some changes to counter culture. It's frustrating to have a test run with such long pauses. I'm not 100% sure why such large numbers are needed, but I think the large numbers could only happen in CI where the long pause won't be noticed.

total test run before PR: ~ 30s
total test run after PR: ~ 5s