### PR TITLE
support custom touch column

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -56,7 +56,9 @@ module CounterCulture
           # and here we update the timestamp, if so desired
           if touch
             current_time = obj.send(:current_time_from_proper_timezone)
-            obj.send(:timestamp_attributes_for_update_in_model).each do |timestamp_column|
+            timestamp_columns = obj.send(:timestamp_attributes_for_update_in_model)
+            timestamp_columns << touch if touch != true
+            timestamp_columns.each do |timestamp_column|
               updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:db)}'"
             end
           end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1412,6 +1412,20 @@ describe "CounterCulture" do
     expect(product.created_at.to_i).to be < product.updated_at.to_i
   end
 
+  it "should update the timestamp for custom column if touch: rexiews_updated_at is set" do
+    product = Product.create
+
+    sleep 1
+
+    Review.create :product_id => product.id
+
+    product.reload
+
+    expect(product.created_at.to_i).to be < product.rexiews_updated_at.to_i
+  end
+
+
+
   it "should update counts correctly when creating using nested attributes" do
     user = User.create(:reviews_attributes => [{:some_text => 'abc'}, {:some_text => 'xyz'}])
     user.reload

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -3,7 +3,7 @@ class Review < ActiveRecord::Base
   belongs_to :product
 
   counter_culture :product, :touch => true
-  counter_culture :product, :column_name => 'rexiews_count'
+  counter_culture :product, :column_name => 'rexiews_count', touch: :rexiews_updated_at
   counter_culture :user
   counter_culture :user, :column_name => proc { |model| model.review_type && model.review_type != 'null' ? "#{model.review_type}_count" : nil }, :column_names => {"reviews.review_type = 'using'" => 'using_count', "reviews.review_type = 'tried'" => 'tried_count', "reviews.review_type = 'null'" => nil}
   counter_culture :user, :column_name => 'review_approvals_count', :delta_column => 'approvals'

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "reviews_count",               :default => 0, :null => false
     t.integer  "simple_reviews_count",        :default => 0, :null => false
     t.integer  "rexiews_count",               :default => 0, :null => false
+    t.datetime "rexiews_updated_at"
     t.integer  "twitter_reviews_count",       :default => 0, :null => false
     t.integer  "category_id"
     t.datetime "created_at"


### PR DESCRIPTION
We should be able (like in Rails) touch custom columns when we specify column name instead true  for touch. 

    counter_culture :product, touch: :rexiews_updated_at

