### PR TITLE
Allow updating of specific instance to trigger Papertrail versioning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
 
   # to test the integration
   gem "paranoia"
+  gem "paper_trail"
 end
 
 group :development do

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -15,6 +15,7 @@ module CounterCulture
       @touch = options.fetch(:touch, false)
       @delta_magnitude = options[:delta_magnitude] || 1
       @execute_after_commit = options.fetch(:execute_after_commit, false)
+      @with_papertrail = options.fetch(:with_papertrail, false)
     end
 
     # increments or decrements a counter cache
@@ -28,6 +29,7 @@ module CounterCulture
     #   :was => whether to get the current value or the old value of the
     #      first part of the relation
     #   :execute_after_commit => execute the column update outside of the transaction to avoid deadlocks
+    #   :with_papertrail => update the column via Papertrail touch_with_version method
     def change_counter_cache(obj, options)
       change_counter_column = options.fetch(:counter_column) { counter_cache_name_for(obj) }
 
@@ -42,6 +44,11 @@ module CounterCulture
                           else
                             counter_delta_magnitude_for(obj)
                           end
+
+        klass = relation_klass(relation, source: obj, was: options[:was])
+        primary_key = relation_primary_key(relation, source: obj, was: options[:was])
+        instance = @with_papertrail ? klass.find_by(primary_key => id_to_change) : nil
+
         execute_change_counter_cache(obj, options) do
           # increment or decrement?
           operator = options[:increment] ? '+' : '-'
@@ -50,6 +57,7 @@ module CounterCulture
           quoted_column = model.connection.quote_column_name(change_counter_column)
 
           updates = []
+          instance.lock! if instance
           # this updates the actual counter
           updates << "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{delta_magnitude}"
           # and here we update the timestamp, if so desired
@@ -62,9 +70,18 @@ module CounterCulture
             end
           end
 
-          klass = relation_klass(relation, source: obj, was: options[:was])
-          primary_key = relation_primary_key(relation, source: obj, was: options[:was])
-          klass.where(primary_key => id_to_change).update_all updates.join(', ')
+          if instance
+            if options[:increment]
+              instance[change_counter_column] = instance[change_counter_column] + delta_magnitude
+            else
+              instance[change_counter_column] = instance[change_counter_column] - delta_magnitude
+            end
+
+            instance.paper_trail.touch_with_version
+          else
+            klass.where(primary_key => id_to_change).update_all updates.join(', ')
+          end
+
         end
       end
     end

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -44,10 +44,6 @@ module CounterCulture
                           else
                             counter_delta_magnitude_for(obj)
                           end
-
-        klass = relation_klass(relation, source: obj, was: options[:was])
-        primary_key = relation_primary_key(relation, source: obj, was: options[:was])
-
         execute_change_counter_cache(obj, options) do
           # increment or decrement?
           operator = options[:increment] ? '+' : '-'
@@ -67,6 +63,9 @@ module CounterCulture
               updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:db)}'"
             end
           end
+
+          klass = relation_klass(relation, source: obj, was: options[:was])
+          primary_key = relation_primary_key(relation, source: obj, was: options[:was])
 
           if @with_papertrail
             instance = klass.find_by(primary_key => id_to_change)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1822,4 +1822,36 @@ describe "CounterCulture" do
       end
     end
   end
+
+  describe "with papertrail support", versioning: true do
+    it "creates a papertrail version when changed" do
+      user = User.create
+      product = Product.create
+
+      expect(product.reviews_count).to eq(0)
+      expect(product.versions.count).to eq(1)
+
+      user.reviews.create :user_id => user.id, :product_id => product.id, :approvals => 13
+
+      product.reload
+
+      expect(product.reviews_count).to eq(1)
+      expect(product.versions.count).to eq(2)
+    end
+
+    it "does not create a papertrail version when papertrail flag not set" do
+      user = User.create
+      product = Product.create
+
+      expect(user.reviews_count).to eq(0)
+      expect(user.versions.count).to eq(1)
+
+      user.reviews.create :user_id => user.id, :product_id => product.id, :approvals => 13
+
+      user.reload
+
+      expect(user.reviews_count).to eq(1)
+      expect(user.versions.count).to eq(1)
+    end
+  end
 end

--- a/spec/models/product.rb
+++ b/spec/models/product.rb
@@ -3,4 +3,5 @@ class Product < ActiveRecord::Base
 
   counter_culture :category, :foreign_key_values => proc {|foreign_key_value| Category.pluck(:id) }
 
+  has_paper_trail
 end

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -2,7 +2,7 @@ class Review < ActiveRecord::Base
   belongs_to :user
   belongs_to :product
 
-  counter_culture :product, :touch => true
+  counter_culture :product, :touch => true, :with_papertrail => true
   counter_culture :product, :column_name => 'rexiews_count', touch: :rexiews_updated_at
   counter_culture :user
   counter_culture :user, :column_name => proc { |model| model.review_type && model.review_type != 'null' ? "#{model.review_type}_count" : nil }, :column_names => {"reviews.review_type = 'using'" => 'using_count', "reviews.review_type = 'tried'" => 'tried_count', "reviews.review_type = 'null'" => nil}

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -9,6 +9,8 @@ class User < ActiveRecord::Base
   has_many :reviews
   accepts_nested_attributes_for :reviews, :allow_destroy => true
 
+  has_paper_trail
+
   default_scope do
     if _default_scope_enabled
       query = joins("LEFT OUTER JOIN companies")

--- a/spec/rails_app/Gemfile
+++ b/spec/rails_app/Gemfile
@@ -23,6 +23,8 @@ gem 'jquery-rails'
 
 gem 'counter_culture', path: '../..'
 
+gem 'paper_trail'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/spec/rails_app/Gemfile.lock
+++ b/spec/rails_app/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: ../..
   specs:
-    counter_culture (0.2.3)
+    counter_culture (1.6.2)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-      after_commit_action (~> 1.0.0)
+      after_commit_action (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -78,6 +78,9 @@ GEM
     minitest (5.9.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    paper_trail (7.0.3)
+      activerecord (>= 4.0, < 5.2)
+      request_store (~> 1.1)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -106,6 +109,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
+    request_store (1.3.2)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -136,10 +140,11 @@ DEPENDENCIES
   coffee-rails
   counter_culture!
   jquery-rails
+  paper_trail
   rails (~> 4.2.0)
   sass-rails
   sqlite3
   uglifier
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/spec/rails_app/config/initializers/paper_trail.rb
+++ b/spec/rails_app/config/initializers/paper_trail.rb
@@ -1,0 +1,1 @@
+PaperTrail.config.track_associations = false

--- a/spec/rails_app/db/migrate/20170609205523_add_papertrail.rb
+++ b/spec/rails_app/db/migrate/20170609205523_add_papertrail.rb
@@ -1,0 +1,81 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class AddPapertrail < ActiveRecord::Migration
+  # Class names of MySQL adapters.
+  # - `MysqlAdapter` - Used by gems: `mysql`, `activerecord-jdbcmysql-adapter`.
+  # - `Mysql2Adapter` - Used by `mysql2` gem.
+  MYSQL_ADAPTERS = [
+    "ActiveRecord::ConnectionAdapters::MysqlAdapter",
+    "ActiveRecord::ConnectionAdapters::Mysql2Adapter"
+  ].freeze
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions, versions_table_options do |t|
+      t.string   :item_type, item_type_options
+      t.integer  :item_id,   null: false
+      t.string   :event,     null: false
+      t.integer  :whodunnit
+      t.text    :object
+      t.text    :object_changes
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, [:item_id, :item_type]
+  end
+
+  private
+
+  # MySQL 5.6 utf8mb4 limit is 191 chars for keys used in indexes.
+  # See https://github.com/airblade/paper_trail/issues/651
+  def item_type_options
+    opt = { null: false }
+    opt[:limit] = 191 if mysql?
+    opt
+  end
+
+  def mysql?
+    MYSQL_ADAPTERS.include?(connection.class.name)
+  end
+
+  # Even modern versions of MySQL still use `latin1` as the default character
+  # encoding. Many users are not aware of this, and run into trouble when they
+  # try to use PaperTrail in apps that otherwise tend to use UTF-8. Postgres, by
+  # comparison, uses UTF-8 except in the unusual case where the OS is configured
+  # with a custom locale.
+  #
+  # - https://dev.mysql.com/doc/refman/5.7/en/charset-applications.html
+  # - http://www.postgresql.org/docs/9.4/static/multibyte.html
+  #
+  # Furthermore, MySQL's original implementation of UTF-8 was flawed, and had
+  # to be fixed later by introducing a new charset, `utf8mb4`.
+  #
+  # - https://mathiasbynens.be/notes/mysql-utf8mb4
+  # - https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html
+  #
+  def versions_table_options
+    if mysql?
+      { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" }
+    else
+      {}
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "rails_app/config/environment"
 
 require 'rspec'
 require 'counter_culture'
+require 'paper_trail/frameworks/rspec'
 
 CI_TEST_RUN = (ENV['TRAVIS'] && 'TRAVIS') || (ENV['CIRCLECI'] && 'CIRCLE') || ENV["CI"] && 'CI'
 


### PR DESCRIPTION
@magnusvk This isn't super pretty, but it seems to work. Basically if you have a model where you need to also record Papertrail versioning for the counter column, you can specify the `with_papertrail` option and it will load the specific instance of the object being modified (with row-level locking), do the counter update, and record a papertrail version row.