### PR TITLE
Check ActiveRecord version instead of Rails version in Reconciler

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -3,6 +3,8 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 module CounterCulture
   class Reconciler
+    ACTIVE_RECORD_VERSION = Gem.loaded_specs["activerecord"].version
+
     attr_reader :counter, :options, :changes
 
     delegate :model, :relation, :full_primary_key, :relation_reflect, :polymorphic?, :to => :counter
@@ -221,7 +223,7 @@ module CounterCulture
       end
 
       def parameterize(string)
-        if Rails.version < '5.0'
+        if ACTIVE_RECORD_VERSION < Gem::Version.new("5.0")
           string.parameterize('_')
         else
           string.parameterize(separator: '_')


### PR DESCRIPTION
My apologies for missing this in my previous PR.

This adds to the changes in https://github.com/magnusvk/counter_culture/pull/190 to allow for reconciliation in non-Rails projects.