### PR TITLE
Error when default_scope is used at mid-level

### DIFF
--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -508,6 +508,28 @@ describe "CounterCulture" do
     expect(product.reviews_count).to eq(1)
   end
 
+  it "increments third-level counter cache on create when default scope at second-level" do
+    Company.with_default_scope do
+      industry = Industry.create
+      company = Company.create :industry_id => industry.id
+      user = User.create :manages_company_id => company.id
+
+      expect(industry.reviews_count).to eq(0)
+      expect(company.reviews_count).to eq(0)
+      expect(user.reviews_count).to eq(0)
+
+      review = Review.create :user_id => user.id
+
+      industry.reload
+      company.reload
+      user.reload
+
+      expect(industry.reviews_count).to eq(1)
+      expect(company.reviews_count).to eq(1)
+      expect(user.reviews_count).to eq(1)
+    end
+  end
+
   it "decrements third-level counter cache on destroy" do
     industry = Industry.create
     company = Company.create :industry_id => industry.id

--- a/spec/models/company.rb
+++ b/spec/models/company.rb
@@ -8,4 +8,30 @@ class Company < ActiveRecord::Base
 
   counter_culture :parent, :column_name => :children_count
 
+  default_scope do
+    if _default_scope_enabled
+      query = joins(:industry)
+      if Rails.version < "5.0.0"
+        query = query.uniq
+      else
+        query = query.distinct
+      end
+    else
+      if Rails.version < "4.0.0"
+        scoped
+      else
+        all
+      end
+    end
+  end
+
+  class << self
+    attr_accessor :_default_scope_enabled
+
+    def with_default_scope
+      @_default_scope_enabled = true
+      yield
+      @_default_scope_enabled = false
+    end
+  end
 end


### PR DESCRIPTION
In the default_scope of second-level model, there is a join with the third-level model. The error will looks something like:
```
Column 'reviews_count' in field list is ambiguous: UPDATE `companies` INNER JOIN `indistries` ON `companies`.`id` = `industries`.`company_id` SET `reviews_count` = COALESCE(`reviews_count`, 0) + 1, updated_at = '2017-11-25 06:35:09' WHERE `companies`.`id` = 2
```
So the catch is it's trying to update the ```reviews_count``` column of the join table in which there are duplicated ```reviews_count``` column, hence ```ambiguous```.
I had a fix for this, but havent been able to replicate the issue in my test-case.