### PR TITLE
[fix] generate migration template with version for rails >= 5

### DIFF
--- a/lib/generators/counter_culture_generator.rb
+++ b/lib/generators/counter_culture_generator.rb
@@ -11,7 +11,7 @@ class CounterCultureGenerator < ActiveRecord::Generators::Base
   source_root File.expand_path("../templates", __FILE__)
 
   def generate_migration
-    migration_template "counter_culture_migration.rb.erb", "db/migrate/#{migration_file_name}"
+    migration_template "counter_culture_migration.rb.erb", "db/migrate/#{migration_file_name}", migration_version: migration_version
   end
 
   def migration_name
@@ -24,6 +24,12 @@ class CounterCultureGenerator < ActiveRecord::Generators::Base
 
   def migration_class_name
     migration_name.camelize
+  end
+
+  def migration_version
+    if Rails.version.start_with? '5.'
+      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    end
   end
 
 end

--- a/lib/generators/templates/counter_culture_migration.rb.erb
+++ b/lib/generators/templates/counter_culture_migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
 
   def self.up
 <% counter_cache_columns.each do |column| %>


### PR DESCRIPTION
In Rails > 5 need to insert rails version to migrations. 
This fix inserting this version only for Rails versions > 5


Caused by:
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class AddMessagesCountToConversationies < ActiveRecord::Migration[4.2]
