### PR TITLE
improvement: avoid extra query in case of unchanged relation

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -114,14 +114,19 @@ module CounterCulture
           counter_cache_name_was = counter.counter_cache_name_for(counter.previous_model(self))
           counter_cache_name = counter.counter_cache_name_for(self)
 
-          if counter.first_level_relation_changed?(self) ||
-              (counter.delta_column && counter.attribute_changed?(self, counter.delta_column)) ||
-              counter_cache_name != counter_cache_name_was
+          relation_was_changed = counter.first_level_relation_changed?(self)
+          delta_was_changed = counter.delta_column && counter.attribute_changed?(self, counter.delta_column)
 
+          if relation_was_changed || delta_was_changed || counter_cache_name != counter_cache_name_was
             # increment the counter cache of the new value
-            counter.change_counter_cache(self, :increment => true, :counter_column => counter_cache_name)
+            counter.change_counter_cache(self, increment: true, counter_column: counter_cache_name)
             # decrement the counter cache of the old value
-            counter.change_counter_cache(self, :increment => false, :was => true, :counter_column => counter_cache_name_was)
+            counter.change_counter_cache(self,
+              increment:            false,
+              delta_was_changed:    delta_was_changed,
+              relation_was_changed: relation_was_changed,
+              counter_column:       counter_cache_name_was,
+            )
           end
         end
       end


### PR DESCRIPTION
I have many `counter_culture` in one model with dynamic counter cache columns
and I noticed `counter_culture` does many queries for relation even it has already loaded and has not been changed
for example
```
    SQL (1.2ms)  UPDATE "votes" SET "value" = $1, "updated_at" = $2 WHERE "votes"."id" = $3  [["value", 0], ["updated_at", "2017-12-07 09:16:36.723428"], ["id", 16]]
  Post Load (1.2ms)  SELECT  "posts".* FROM "posts" WHERE (posts.id = 64518) ORDER BY "posts"."id" ASC LIMIT $1  [["LIMIT", 1]]
  Category Load (1.2ms)  SELECT  "categories".* FROM "categories" WHERE "categories"."id" = $1 LIMIT $2  [["id", 1693], ["LIMIT", 1]]
  SQL (1.2ms)  UPDATE "categories" SET "engagement_score" = COALESCE("engagement_score", 0) - 1, updated_at = '2017-12-07 09:16:36' WHERE "categories"."id" = $1  [["id", 1693]]
  Post Load (1.4ms)  SELECT  "posts".* FROM "posts" WHERE (posts.id = 64518) ORDER BY "posts"."id" ASC LIMIT $1  [["LIMIT", 1]]
  SQL (1.3ms)  UPDATE "posts" SET "engagement_score" = COALESCE("engagement_score", 0) - 1, updated_at = '2017-12-07 09:16:36' WHERE "posts"."id" = $1  [["id", 64518]]
  Post Load (1.3ms)  SELECT  "posts".* FROM "posts" WHERE (posts.id = 64518) ORDER BY "posts"."id" ASC LIMIT $1  [["LIMIT", 1]]
  SQL (1.5ms)  UPDATE "posts" SET "upvote_count" = COALESCE("upvote_count", 0) - 1 WHERE "posts"."id" = $1  [["id", 64518]]
   (2.1ms)  COMMIT
```
so I split `was` option into `relation_was_changed` and `delta_was_changed`