### PR TITLE
Allow updating of timestamps when fixing counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,18 @@ Product.counter_culture_fix_counts batch_size: 100
 
 ```counter_culture_fix_counts``` is optimized to minimize the number of queries and runs very quickly.
 
+Similarly to `counter_culture`, it is possible to update the records' timestamps, when fixing counts. If you would like to update the default timestamp field, pass `touch: true` option:
+
+```ruby
+Product.counter_culture_fix_counts touch: true
+```
+
+If you have specified a custom timestamps column, pass its name as the value for the `touch` option:
+
+```ruby
+Product.counter_culture_fix_counts touch: category_count_changed
+```
+
 #### Handling dynamic column names
 
 Manually populating counter caches with dynamic column names requires additional configuration:

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -63,7 +63,7 @@ module CounterCulture
           next if options[:exclude] && options[:exclude].include?(counter.relation)
           next if options[:only] && !options[:only].include?(counter.relation)
 
-          reconciler = CounterCulture::Reconciler.new(counter, options.slice(:skip_unsupported, :batch_size))
+          reconciler = CounterCulture::Reconciler.new(counter, options.slice(:skip_unsupported, :batch_size, :touch))
           reconciler.reconcile!
           reconciler.changes
         end.compact

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -948,6 +948,63 @@ describe "CounterCulture" do
     expect(Review.counter_culture_fix_counts(skip_unsupported: true)).to eq([{ entity: 'User', id: user1.id, what: 'reviews_count', right: 1, wrong: 2 }])
   end
 
+  it 'should update the timestamp when fixing counts with `touch: true`' do
+    product = Product.create
+    review = Review.create product: product
+
+    product.update_column :reviews_count, 2
+
+    product.reload
+
+    old_product_updated_at = product.updated_at
+
+    Timecop.travel(1.second.from_now) do
+      Review.counter_culture_fix_counts(skip_unsupported: true, only: :product, touch: true)
+
+      product.reload
+
+      expect(product.updated_at).to be > old_product_updated_at
+    end
+  end
+
+  it 'should not update the timestamp when fixing counts without `touch: true`' do
+    product = Product.create
+    review = Review.create product: product
+
+    product.update_column :reviews_count, 2
+
+    product.reload
+
+    old_product_updated_at = product.updated_at
+
+    Timecop.travel(2.second.from_now) do
+      Review.counter_culture_fix_counts(skip_unsupported: true, only: :product)
+
+      product.reload
+
+      expect(product.updated_at).to eq old_product_updated_at
+    end
+  end
+
+  it 'should update the timestamp of a custom column when fixing counts with touch: rexiews_updated_at' do
+    product = Product.create
+    review = Review.create product: product
+
+    product.update_column :rexiews_count, 2
+
+    product.reload
+
+    old_rexiews_updated_at = product.rexiews_updated_at
+
+    Timecop.travel(1.second.from_now) do
+      Review.counter_culture_fix_counts(skip_unsupported: true, touch: :rexiews_updated_at)
+
+      product.reload
+
+      expect(product.rexiews_updated_at).to be > old_rexiews_updated_at
+    end
+  end
+
   it "should fix a simple counter cache correctly" do
     user = User.create
     product = Product.create


### PR DESCRIPTION
As discussed in #210, I'm opening a PR to allow updating of timestamps for `counter_culture_fix_counts`. I appreciate your feedback.