### PR TITLE
Support Discard for soft-deletes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,18 @@ group :development, :test do
   gem "awesome_print"
   gem "timecop"
 
-  # to test the integration
-  gem "discard"
-  gem "paranoia"
+  # To test integrations
+
+  # Both the paranoia and discard integrations require Rails > 4.2
+  # Actually parsing the resolved rails version is complicated, so
+  # we're basing this on the incompatible Rails version strings from
+  # .travis.yml
+
+  unless ['~> 3.2.0', '~> 4.0.0', '~> 4.1.0'].include?(rails)
+    gem "discard"
+    gem "paranoia"
+  end
+
   if RUBY_VERSION < "2.3.0"
     gem "paper_trail", "< 9.0.0"
   else

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem "timecop"
 
   # to test the integration
+  gem "discard"
   gem "paranoia"
   if RUBY_VERSION < "2.3.0"
     gem "paper_trail", "< 9.0.0"

--- a/README.md
+++ b/README.md
@@ -313,17 +313,28 @@ Product.counter_culture_fix_counts skip_unsupported: true
 
 Manually populating counter caches with dynamically over-written foreign keys (```:foreign_key_values``` option) is not supported. You will have to write code to handle this case yourself.
 
-### Soft-deletes / `paranoia` gem
+### Soft-deletes with `paranoia` or `discard`
 
-This gem will keep counters correctly updated when using the
-[`paranoia` gem](https://github.com/rubysherpas/paranoia)
-for soft-delete support. However, to ensure that counts are incremented after a
-restore you have to make sure that the call to `acts_as_paranoid` comes before
-the call to `counter_culture` in your model:
+This gem will keep counters correctly updated when using
+[paranoia](https://github.com/rubysherpas/paranoia) or [discard](https://github.com/jhawthorn/discard) for soft-delete support. However, to ensure that counts are incremented after a
+restore you have to make sure that the to set up soft deletion (via `acts_as_paranoid` or `include Discard::Model`) before the call to `counter_culture` in your model:
+
+#### Paranoia
 
 ```ruby
 class SoftDelete < ActiveRecord::Base
   acts_as_paranoid
+
+  belongs_to :company
+  counter_culture :company
+end
+```
+
+#### Discard
+
+```ruby
+class SoftDelete < ActiveRecord::Base
+  include Discard::Model
 
   belongs_to :company
   counter_culture :company

--- a/README.md
+++ b/README.md
@@ -315,9 +315,12 @@ Manually populating counter caches with dynamically over-written foreign keys (`
 
 ### Soft-deletes with `paranoia` or `discard`
 
-This gem will keep counters correctly updated when using
-[paranoia](https://github.com/rubysherpas/paranoia) or [discard](https://github.com/jhawthorn/discard) for soft-delete support. However, to ensure that counts are incremented after a
-restore you have to make sure that the to set up soft deletion (via `acts_as_paranoid` or `include Discard::Model`) before the call to `counter_culture` in your model:
+This gem will keep counters correctly updated in Rails 4.2 or later when using
+[paranoia](https://github.com/rubysherpas/paranoia) or
+[discard](https://github.com/jhawthorn/discard) for soft-delete support.
+However, to ensure that counts are incremented after a restore you have
+to make sure that the to set up soft deletion (via `acts_as_paranoid` or
+`include Discard::Model`) before the call to `counter_culture` in your model:
 
 #### Paranoia
 

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -226,6 +226,14 @@ module CounterCulture
             if model.column_names.include?('deleted_at')
               joins_sql += " AND #{target_table_alias}.deleted_at IS NULL"
             end
+
+            # respect the discard column if it exists
+            if defined?(Discard::Model) &&
+               model.include?(Discard::Model) &&
+               model.column_names.include?(model.discard_column.to_s)
+
+              joins_sql += " AND #{target_table_alias}.#{model.discard_column} IS NULL"
+            end
           end
           joins_sql
         end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -21,7 +21,7 @@ require 'models/another_post'
 require 'models/another_post_comment'
 require 'models/person'
 require 'models/transaction'
-require 'models/soft_delete'
+require 'models/soft_delete_paranoia'
 require 'models/conversation'
 require 'models/candidate_profile'
 require 'models/candidate'
@@ -1703,55 +1703,55 @@ describe "CounterCulture" do
     it "works" do
       skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
       company = Company.create!
-      expect(company.soft_deletes_count).to eq(0)
-      sd = SoftDelete.create!(company_id: company.id)
-      expect(company.reload.soft_deletes_count).to eq(1)
+      expect(company.soft_delete_paranoia_count).to eq(0)
+      sd = SoftDeleteParanoia.create!(company_id: company.id)
+      expect(company.reload.soft_delete_paranoia_count).to eq(1)
 
       sd.destroy
       sd.reload
       expect(sd.deleted_at).to be_truthy
-      expect(company.reload.soft_deletes_count).to eq(0)
+      expect(company.reload.soft_delete_paranoia_count).to eq(0)
 
-      company.update_attributes(soft_deletes_count: 100)
-      expect(company.reload.soft_deletes_count).to eq(100)
-      SoftDelete.counter_culture_fix_counts
-      expect(company.reload.soft_deletes_count).to eq(0)
+      company.update_attributes(soft_delete_paranoia_count: 100)
+      expect(company.reload.soft_delete_paranoia_count).to eq(100)
+      SoftDeleteParanoia.counter_culture_fix_counts
+      expect(company.reload.soft_delete_paranoia_count).to eq(0)
 
       sd.restore
-      expect(company.reload.soft_deletes_count).to eq(1)
+      expect(company.reload.soft_delete_paranoia_count).to eq(1)
     end
 
     it "runs destroy callback only once" do
       skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
 
       company = Company.create!
-      sd = SoftDelete.create!(company_id: company.id)
+      sd = SoftDeleteParanoia.create!(company_id: company.id)
 
-      expect(company.reload.soft_deletes_count).to eq(1)
-
-      sd.destroy
-      expect(company.reload.soft_deletes_count).to eq(0)
+      expect(company.reload.soft_delete_paranoia_count).to eq(1)
 
       sd.destroy
-      expect(company.reload.soft_deletes_count).to eq(0)
+      expect(company.reload.soft_delete_paranoia_count).to eq(0)
+
+      sd.destroy
+      expect(company.reload.soft_delete_paranoia_count).to eq(0)
     end
 
     it "runs restore callback only once" do
       skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
 
       company = Company.create!
-      sd = SoftDelete.create!(company_id: company.id)
+      sd = SoftDeleteParanoia.create!(company_id: company.id)
 
-      expect(company.reload.soft_deletes_count).to eq(1)
+      expect(company.reload.soft_delete_paranoia_count).to eq(1)
 
       sd.destroy
-      expect(company.reload.soft_deletes_count).to eq(0)
+      expect(company.reload.soft_delete_paranoia_count).to eq(0)
 
       sd.restore
-      expect(company.reload.soft_deletes_count).to eq(1)
+      expect(company.reload.soft_delete_paranoia_count).to eq(1)
 
       sd.restore
-      expect(company.reload.soft_deletes_count).to eq(1)
+      expect(company.reload.soft_delete_paranoia_count).to eq(1)
     end
   end
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1699,7 +1699,7 @@ describe "CounterCulture" do
     end
   end
 
-  describe "when using acts_as_paranoia" do
+  describe "when using paranoia" do
     it "works" do
       skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
       company = Company.create!

--- a/spec/models/soft_delete_discard.rb
+++ b/spec/models/soft_delete_discard.rb
@@ -1,5 +1,5 @@
 class SoftDeleteDiscard < ActiveRecord::Base
-  include Discard::Model
+  include Discard::Model if defined?(Discard::Model)
 
   belongs_to :company
   counter_culture :company

--- a/spec/models/soft_delete_discard.rb
+++ b/spec/models/soft_delete_discard.rb
@@ -1,0 +1,6 @@
+class SoftDeleteDiscard < ActiveRecord::Base
+  include Discard::Model
+
+  belongs_to :company
+  counter_culture :company
+end

--- a/spec/models/soft_delete_paranoia.rb
+++ b/spec/models/soft_delete_paranoia.rb
@@ -1,5 +1,5 @@
 class SoftDeleteParanoia < ActiveRecord::Base
-  acts_as_paranoid
+  acts_as_paranoid if respond_to?(:acts_as_paranoid)
 
   belongs_to :company
   counter_culture :company

--- a/spec/models/soft_delete_paranoia.rb
+++ b/spec/models/soft_delete_paranoia.rb
@@ -1,4 +1,4 @@
-class SoftDelete < ActiveRecord::Base
+class SoftDeleteParanoia < ActiveRecord::Base
   acts_as_paranoid
 
   belongs_to :company

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "parent_id"
     t.integer  "children_count",      :default => 0, :null => false
     t.integer  "soft_delete_paranoia_count",  :default => 0, :null => false
+    t.integer  "soft_delete_discards_count",  :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -179,6 +180,11 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   create_table "soft_delete_paranoia", :force => true do |t|
     t.integer "company_id", :null => false
     t.timestamp "deleted_at"
+  end
+
+  create_table "soft_delete_discards", :force => true do |t|
+    t.integer "company_id", :null => false
+    t.timestamp "discarded_at"
   end
 
   #polymorphic

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "review_approvals_count",      :default => 0, :null => false
     t.integer  "parent_id"
     t.integer  "children_count",      :default => 0, :null => false
-    t.integer  "soft_deletes_count",  :default => 0, :null => false
+    t.integer  "soft_delete_paranoia_count",  :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer "monetary_value", :null => false
   end
 
-  create_table "soft_deletes", :force => true do |t|
+  create_table "soft_delete_paranoia", :force => true do |t|
     t.integer "company_id", :null => false
     t.timestamp "deleted_at"
   end


### PR DESCRIPTION
This adds support for properly counting things when using the [Discard](https://github.com/jhawthorn/discard) gem for soft deletes.