### PR TITLE
Don't wrap updates in counter_culture_active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.13.0 (June 12, 2018)
+
+Bugfixes:
+  - Multiple updates in one transaction will now be processed correctly (#222)
+
+Deprecations:
+  - execute_after_commit is now deprecated and will be removed in gem version 2.0
+
 ## 1.12.0 (June 8, 2018)
 
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-## 1.13.0 (June 12, 2018)
+## 2.0.0 (June 12, 2018)
+
+Breaking changes:
+  - execute_after_commit was removed
+  - Removed workaround for incorrect counts when triggering updates from an `after_create` hook. Your options if this applies to you:
+    * continue using counter_culture 1.12.0
+    * upgrade to Rails 5.1.5 which fixes the underlying issue in Rails
+    * avoid triggering further updates on the same model in `after_create`; simply set the attribute in `before_create` instead
 
 Bugfixes:
   - Multiple updates in one transaction will now be processed correctly (#222)
-
-Deprecations:
-  - execute_after_commit is now deprecated and will be removed in gem version 2.0
 
 ## 1.12.0 (June 8, 2018)
 

--- a/README.md
+++ b/README.md
@@ -216,16 +216,6 @@ You may also specify a custom timestamp column that gets updated only when a par
 
 With this option, any time the `category_counter_cache` changes both the `category_count_changed` and `updated_at` columns will get updated.
 
-### Executing counter cache updates after commit
-
-By default, counter_culture will run counter cache updates inside of the same ActiveRecord transaction that triggered it. (Note that this bevavior [changed from version 0.2.3 to 1.0.0](CHANGELOG.md#100-november-15-2016).) If you would like to run counter cache updates outside of that transaction, for example because you are experiencing [deadlocks with older versions of PostgreSQL](http://mina.naguib.ca/blog/2010/11/22/postgresql-foreign-key-deadlocks.html), you can enable that behavior:
-```ruby
-  counter_culture :category, execute_after_commit: true
-```
-
-Please note that using `execute_after_commit` in conjunction with transactional
-fixtures will lead to your tests no longer seeing updated counter values.
-
 ### Manually populating counter cache values
 
 You will sometimes want to populate counter-cache values from primary data. This is required when adding counter-caches to existing data. It is also recommended to run this regularly (at BestVendor, we run it once a week) to catch any incorrect values in the counter caches.

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -1,6 +1,6 @@
 module CounterCulture
   class Counter
-    CONFIG_OPTIONS = [ :column_names, :counter_cache_name, :delta_column, :foreign_key_values, :touch, :delta_magnitude, :execute_after_commit ]
+    CONFIG_OPTIONS = [ :column_names, :counter_cache_name, :delta_column, :foreign_key_values, :touch, :delta_magnitude]
     ACTIVE_RECORD_VERSION = Gem.loaded_specs["activerecord"].version
 
     attr_reader :model, :relation, *CONFIG_OPTIONS
@@ -9,13 +9,16 @@ module CounterCulture
       @model = model
       @relation = relation.is_a?(Enumerable) ? relation : [relation]
 
+      if options.fetch(:execute_after_commit, false)
+        fail("execute_after_commit was removed; updates now run within the transaction")
+      end
+
       @counter_cache_name = options.fetch(:column_name, "#{model.name.tableize}_count")
       @column_names = options[:column_names]
       @delta_column = options[:delta_column]
       @foreign_key_values = options[:foreign_key_values]
       @touch = options.fetch(:touch, false)
       @delta_magnitude = options[:delta_magnitude] || 1
-      @execute_after_commit = options.fetch(:execute_after_commit, false)
       @with_papertrail = options.fetch(:with_papertrail, false)
     end
 
@@ -29,7 +32,6 @@ module CounterCulture
     #   :delta_column => override the default count delta (1) with the value of this column in the counted record
     #   :was => whether to get the current value or the old value of the
     #      first part of the relation
-    #   :execute_after_commit => execute the column update outside of the transaction to avoid deadlocks
     #   :with_papertrail => update the column via Papertrail touch_with_version method
     def change_counter_cache(obj, options)
       change_counter_column = options.fetch(:counter_column) { counter_cache_name_for(obj) }
@@ -45,43 +47,41 @@ module CounterCulture
                           else
                             counter_delta_magnitude_for(obj)
                           end
-        execute_change_counter_cache(obj, options) do
-          # increment or decrement?
-          operator = options[:increment] ? '+' : '-'
+        # increment or decrement?
+        operator = options[:increment] ? '+' : '-'
 
-          # we don't use Rails' update_counters because we support changing the timestamp
-          quoted_column = model.connection.quote_column_name(change_counter_column)
+        # we don't use Rails' update_counters because we support changing the timestamp
+        quoted_column = model.connection.quote_column_name(change_counter_column)
 
-          updates = []
-          # this updates the actual counter
-          updates << "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{delta_magnitude}"
-          # and here we update the timestamp, if so desired
-          if touch
-            current_time = obj.send(:current_time_from_proper_timezone)
-            timestamp_columns = obj.send(:timestamp_attributes_for_update_in_model)
-            timestamp_columns << touch if touch != true
-            timestamp_columns.each do |timestamp_column|
-              updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:db)}'"
-            end
+        updates = []
+        # this updates the actual counter
+        updates << "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{delta_magnitude}"
+        # and here we update the timestamp, if so desired
+        if touch
+          current_time = obj.send(:current_time_from_proper_timezone)
+          timestamp_columns = obj.send(:timestamp_attributes_for_update_in_model)
+          timestamp_columns << touch if touch != true
+          timestamp_columns.each do |timestamp_column|
+            updates << "#{timestamp_column} = '#{current_time.to_formatted_s(:db)}'"
           end
-
-          klass = relation_klass(relation, source: obj, was: options[:was])
-          primary_key = relation_primary_key(relation, source: obj, was: options[:was])
-
-          if @with_papertrail
-            instance = klass.where(primary_key => id_to_change).first
-            if instance
-              if instance.paper_trail.respond_to?(:save_with_version)
-                # touch_with_version is deprecated starting in PaperTrail 9.0.0
-                instance.paper_trail.save_with_version(validate: false)
-              else
-                instance.paper_trail.touch_with_version
-              end
-            end
-          end
-
-          klass.where(primary_key => id_to_change).update_all updates.join(', ')
         end
+
+        klass = relation_klass(relation, source: obj, was: options[:was])
+        primary_key = relation_primary_key(relation, source: obj, was: options[:was])
+
+        if @with_papertrail
+          instance = klass.where(primary_key => id_to_change).first
+          if instance
+            if instance.paper_trail.respond_to?(:save_with_version)
+              # touch_with_version is deprecated starting in PaperTrail 9.0.0
+              instance.paper_trail.save_with_version(validate: false)
+            else
+              instance.paper_trail.touch_with_version
+            end
+          end
+        end
+
+        klass.where(primary_key => id_to_change).update_all updates.join(', ')
       end
     end
 
@@ -278,14 +278,6 @@ module CounterCulture
     end
 
     private
-    def execute_change_counter_cache(obj, options)
-      if execute_after_commit
-        obj.execute_after_commit { yield }
-      else
-        yield
-      end
-    end
-
     def attribute_was(obj, attr)
       changes_method =
         if ACTIVE_RECORD_VERSION >= Gem::Version.new("5.1.0")

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -51,6 +51,12 @@ module CounterCulture
           raise ":column_names must be a Hash of conditions and column names"
         end
 
+        if options[:execute_after_commit]
+           ActiveSupport::Deprecation.warn(
+             'execute_after_commit is deprecated and will be removed from '\
+             'counter_culture 2.0')
+        end
+
         # add the counter to our collection
         @after_commit_counter_cache << Counter.new(self, relation, options)
       end
@@ -89,61 +95,42 @@ module CounterCulture
     end
 
     private
-    # need to make sure counter_culture is only activated once
-    # per commit; otherwise, if we do an update in an after_create,
-    # we would be triggered twice within the same transaction -- once
-    # for the create, once for the update
-    def _wrap_in_counter_culture_active(&block)
-      if @_counter_culture_active
-        # don't do anything; we are already active for this transaction
-      else
-        block.call
-        execute_after_commit { @_counter_culture_active = false}
-      end
-    end
-
     # called by after_create callback
     def _update_counts_after_create
-      _wrap_in_counter_culture_active do
-        @_counter_culture_active = true
-        self.class.after_commit_counter_cache.each do |counter|
-          # increment counter cache
-          counter.change_counter_cache(self, :increment => true)
-        end
+      @_counter_culture_active = true
+      self.class.after_commit_counter_cache.each do |counter|
+        # increment counter cache
+        counter.change_counter_cache(self, :increment => true)
       end
     end
 
     # called by after_destroy callback
     def _update_counts_after_destroy
-      _wrap_in_counter_culture_active do
-        @_counter_culture_active = true
-        self.class.after_commit_counter_cache.each do |counter|
-          # decrement counter cache
-          counter.change_counter_cache(self, :increment => false)
-        end
+      @_counter_culture_active = true
+      self.class.after_commit_counter_cache.each do |counter|
+        # decrement counter cache
+        counter.change_counter_cache(self, :increment => false)
       end
     end
 
     # called by after_update callback
     def _update_counts_after_update
-      _wrap_in_counter_culture_active do
-        self.class.after_commit_counter_cache.each do |counter|
-          # figure out whether the applicable counter cache changed (this can happen
-          # with dynamic column names)
-          counter_cache_name_was = counter.counter_cache_name_for(counter.previous_model(self))
-          counter_cache_name = counter.counter_cache_name_for(self)
+      self.class.after_commit_counter_cache.each do |counter|
+        # figure out whether the applicable counter cache changed (this can happen
+        # with dynamic column names)
+        counter_cache_name_was = counter.counter_cache_name_for(counter.previous_model(self))
+        counter_cache_name = counter.counter_cache_name_for(self)
 
-          if counter.first_level_relation_changed?(self) ||
-              (counter.delta_column && counter.attribute_changed?(self, counter.delta_column)) ||
-              counter_cache_name != counter_cache_name_was
+        if counter.first_level_relation_changed?(self) ||
+            (counter.delta_column && counter.attribute_changed?(self, counter.delta_column)) ||
+            counter_cache_name != counter_cache_name_was
 
-            @_counter_culture_active = true
+          @_counter_culture_active = true
 
-            # increment the counter cache of the new value
-            counter.change_counter_cache(self, :increment => true, :counter_column => counter_cache_name)
-            # decrement the counter cache of the old value
-            counter.change_counter_cache(self, :increment => false, :was => true, :counter_column => counter_cache_name_was)
-          end
+          # increment the counter cache of the new value
+          counter.change_counter_cache(self, :increment => true, :counter_column => counter_cache_name)
+          # decrement the counter cache of the old value
+          counter.change_counter_cache(self, :increment => false, :was => true, :counter_column => counter_cache_name_was)
         end
       end
     end

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -97,7 +97,6 @@ module CounterCulture
     private
     # called by after_create callback
     def _update_counts_after_create
-      @_counter_culture_active = true
       self.class.after_commit_counter_cache.each do |counter|
         # increment counter cache
         counter.change_counter_cache(self, :increment => true)
@@ -106,7 +105,6 @@ module CounterCulture
 
     # called by after_destroy callback
     def _update_counts_after_destroy
-      @_counter_culture_active = true
       self.class.after_commit_counter_cache.each do |counter|
         # decrement counter cache
         counter.change_counter_cache(self, :increment => false)
@@ -124,8 +122,6 @@ module CounterCulture
         if counter.first_level_relation_changed?(self) ||
             (counter.delta_column && counter.attribute_changed?(self, counter.delta_column)) ||
             counter_cache_name != counter_cache_name_was
-
-          @_counter_culture_active = true
 
           # increment the counter cache of the new value
           counter.change_counter_cache(self, :increment => true, :counter_column => counter_cache_name)

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -51,12 +51,6 @@ module CounterCulture
           raise ":column_names must be a Hash of conditions and column names"
         end
 
-        if options[:execute_after_commit]
-           ActiveSupport::Deprecation.warn(
-             'execute_after_commit is deprecated and will be removed from '\
-             'counter_culture 2.0')
-        end
-
         # add the counter to our collection
         @after_commit_counter_cache << Counter.new(self, relation, options)
       end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -148,6 +148,34 @@ describe "CounterCulture" do
     expect(user2.reload.review_approvals_count).to eq(69)
   end
 
+  it "works with multiple saves in one transcation" do
+    user = User.create
+    product = Product.create
+
+    expect(user.reviews_count).to eq(0)
+    expect(user.review_approvals_count).to eq(0)
+
+    Review.transaction do
+      review1 = Review.create!(user_id: user.id, product_id: product.id, approvals: 0)
+
+      user.reload
+      expect(user.reviews_count).to eq(1)
+      expect(user.review_approvals_count).to eq(0)
+
+      review1.update_attributes!(approvals: 42)
+
+      user.reload
+      expect(user.reviews_count).to eq(1)
+      expect(user.review_approvals_count).to eq(42)
+
+      review2 = Review.create!(user_id: user.id, product_id: product.id, approvals: 1)
+
+      user.reload
+      expect(user.reviews_count).to eq(2)
+      expect(user.review_approvals_count).to eq(43)
+    end
+  end
+
   it "treats null delta column values as 0" do
     user = User.create
     product = Product.create

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -20,6 +20,7 @@ class Review < ActiveRecord::Base
   after_create :update_some_text
 
   def update_some_text
+    return unless Gem::Version.new(Rails.version) >= Gem::Version.new('5.1.5')
     update_attribute(:some_text, rand(36**12).to_s(36))
   end
 


### PR DESCRIPTION
This is an artifact of updates running after commit by default, which is
no longer the default, or in fact even tested. It causes to problems as
demonstrated by the new (formerly failing) test case.

This also deprecates execute_after_commit, as it is currently untested
and there is no real reason to use it anymore.

Fixes #221.