### PR TITLE
Don't update counts when hard-destroying discarded records

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -23,6 +23,8 @@ module CounterCulture
           before_destroy :_update_counts_after_destroy, if: -> (model) do
             if model.respond_to?(:paranoia_destroyed?)
               !model.paranoia_destroyed?
+            elsif defined?(Discard::Model) && model.class.include?(Discard::Model)
+              !model.discarded?
             else
               true
             end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1784,6 +1784,35 @@ describe "CounterCulture" do
       sd.undiscard
       expect(company.reload.soft_delete_discards_count).to eq(1)
     end
+
+    describe "when calling hard-destroy" do
+      it "does not run destroy callback for discarded records" do
+        skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+        company = Company.create!
+        sd = SoftDeleteDiscard.create!(company_id: company.id)
+
+        expect(company.reload.soft_delete_discards_count).to eq(1)
+
+        sd.discard
+        expect(company.reload.soft_delete_discards_count).to eq(0)
+
+        sd.destroy
+        expect(company.reload.soft_delete_discards_count).to eq(0)
+      end
+
+      it "runs destroy callback for undiscarded records" do
+        skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+        company = Company.create!
+        sd = SoftDeleteDiscard.create!(company_id: company.id)
+
+        expect(company.reload.soft_delete_discards_count).to eq(1)
+
+        sd.destroy
+        expect(company.reload.soft_delete_discards_count).to eq(0)
+      end
+    end
   end
 
   describe "when using paranoia for soft deletes" do


### PR DESCRIPTION
Hi,

this fixes bug when calling destroy on already discarded record (when using Discard for soft-deletes) - counts are currently updated twice (once when discard is called and once when destroy is called).