### PR TITLE
Decrement counter when using paranoia really_destroy!

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -30,6 +30,11 @@ module CounterCulture
             end
           end
 
+          if respond_to?(:before_real_destroy)
+            before_real_destroy :_update_counts_after_destroy,
+              if: -> (model) { !model.paranoia_destroyed? }
+          end
+
           after_update :_update_counts_after_update
 
           if respond_to?(:before_restore)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1869,6 +1869,35 @@ describe "CounterCulture" do
       sd.restore
       expect(company.reload.soft_delete_paranoia_count).to eq(1)
     end
+
+    describe "when calling paranoia really destroy" do
+      it "does not run destroy callback for paranoia destroyed records" do
+        skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+        company = Company.create!
+        sd = SoftDeleteParanoia.create!(company_id: company.id)
+
+        expect(company.reload.soft_delete_paranoia_count).to eq(1)
+
+        sd.destroy
+        expect(company.reload.soft_delete_paranoia_count).to eq(0)
+
+        sd.really_destroy!
+        expect(company.reload.soft_delete_paranoia_count).to eq(0)
+      end
+
+      it "runs really destroy callback for paranoia undestroyed records" do
+        skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+        company = Company.create!
+        expect(company.soft_delete_paranoia_count).to eq(0)
+        sd = SoftDeleteParanoia.create!(company_id: company.id)
+        expect(company.reload.soft_delete_paranoia_count).to eq(1)
+
+        sd.really_destroy!
+        expect{ sd.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(company.reload.soft_delete_paranoia_count).to eq(0)
+      end
+    end
   end
 
   describe "with polymorphic_associations" do


### PR DESCRIPTION
Fixes #228 

With a new version of paranoia gem (>=2.3.0), I have the same issue with decrement counting of a model when I call the  `really_destroy!` method.

I have created the fix for this issue on this MR. 

Please review and merge it. 

Thank you!