### PR TITLE
Don't update running total on soft-deleted records

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -37,7 +37,9 @@ module CounterCulture
           end
 
           after_update :_update_counts_after_update, if: -> (model) do
-            if defined?(Discard::Model) && model.class.include?(Discard::Model)
+            if model.respond_to?(:paranoia_destroyed?)
+              !model.paranoia_destroyed?
+            elsif defined?(Discard::Model) && model.class.include?(Discard::Model)
               !model.discarded?
             else
               true

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -36,7 +36,13 @@ module CounterCulture
               if: -> (model) { !model.paranoia_destroyed? }
           end
 
-          after_update :_update_counts_after_update
+          after_update :_update_counts_after_update, if: -> (model) do
+            if defined?(Discard::Model) && model.class.include?(Discard::Model)
+              !model.discarded?
+            else
+              true
+            end
+          end
 
           if respond_to?(:before_restore)
             before_restore :_update_counts_after_create,

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1813,6 +1813,39 @@ describe "CounterCulture" do
         expect(company.reload.soft_delete_discards_count).to eq(0)
       end
     end
+
+    describe "dynamic column names with totaling instead of counting" do
+      describe 'when updating discarded records' do
+        it 'does not update sum' do
+          skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+          company = Company.create!
+          sd = SoftDeleteDiscard.create!(company_id: company.id, value: 5)
+
+          expect(company.reload.soft_delete_discard_values_sum).to eq(5)
+
+          sd.discard
+          expect(company.reload.soft_delete_discard_values_sum).to eq(0)
+
+          sd.update value: 10
+          expect(company.reload.soft_delete_discard_values_sum).to eq(0)
+        end
+      end
+
+      describe 'when updating undiscarded records' do
+        it 'updates sum' do
+          skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+          company = Company.create!
+          sd = SoftDeleteDiscard.create!(company_id: company.id, value: 5)
+
+          expect(company.reload.soft_delete_discard_values_sum).to eq(5)
+
+          sd.update value: 10
+          expect(company.reload.soft_delete_discard_values_sum).to eq(10)
+        end
+      end
+    end
   end
 
   describe "when using paranoia for soft deletes" do

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1931,6 +1931,39 @@ describe "CounterCulture" do
         expect(company.reload.soft_delete_paranoia_count).to eq(0)
       end
     end
+
+    describe "dynamic column names with totaling instead of counting" do
+      describe 'when updating soft deleted records' do
+        it 'does not update sum' do
+          skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+          company = Company.create!
+          sd = SoftDeleteParanoia.create!(company_id: company.id, value: 5)
+
+          expect(company.reload.soft_delete_paranoia_values_sum).to eq(5)
+
+          sd.destroy
+          expect(company.reload.soft_delete_paranoia_values_sum).to eq(0)
+
+          sd.update value: 10
+          expect(company.reload.soft_delete_paranoia_values_sum).to eq(0)
+        end
+      end
+
+      describe 'when updating undestroyed records' do
+        it 'updates sum' do
+          skip("Unsupported in this version of Rails") if Rails.version < "4.2.0"
+
+          company = Company.create!
+          sd = SoftDeleteParanoia.create!(company_id: company.id, value: 5)
+
+          expect(company.reload.soft_delete_paranoia_values_sum).to eq(5)
+
+          sd.update value: 10
+          expect(company.reload.soft_delete_paranoia_values_sum).to eq(10)
+        end
+      end
+    end
   end
 
   describe "with polymorphic_associations" do

--- a/spec/models/soft_delete_discard.rb
+++ b/spec/models/soft_delete_discard.rb
@@ -3,4 +3,5 @@ class SoftDeleteDiscard < ActiveRecord::Base
 
   belongs_to :company
   counter_culture :company
+  counter_culture :company, column_name: 'soft_delete_discard_values_sum', delta_column: 'value'
 end

--- a/spec/models/soft_delete_paranoia.rb
+++ b/spec/models/soft_delete_paranoia.rb
@@ -3,4 +3,5 @@ class SoftDeleteParanoia < ActiveRecord::Base
 
   belongs_to :company
   counter_culture :company
+  counter_culture :company, column_name: 'soft_delete_paranoia_values_sum', delta_column: 'value'
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "children_count",      :default => 0, :null => false
     t.integer  "soft_delete_paranoia_count",  :default => 0, :null => false
     t.integer  "soft_delete_discards_count",  :default => 0, :null => false
+    t.integer  "soft_delete_discard_values_sum", :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -184,6 +185,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
 
   create_table "soft_delete_discards", :force => true do |t|
     t.integer "company_id", :null => false
+    t.integer "value", :default => 0
     t.timestamp "discarded_at"
   end
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "parent_id"
     t.integer  "children_count",      :default => 0, :null => false
     t.integer  "soft_delete_paranoia_count",  :default => 0, :null => false
+    t.integer  "soft_delete_paranoia_values_sum", :default => 0, :null => false
     t.integer  "soft_delete_discards_count",  :default => 0, :null => false
     t.integer  "soft_delete_discard_values_sum", :default => 0, :null => false
     t.datetime "created_at"
@@ -180,6 +181,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
 
   create_table "soft_delete_paranoia", :force => true do |t|
     t.integer "company_id", :null => false
+    t.integer "value", :default => 0
     t.timestamp "deleted_at"
   end
 


### PR DESCRIPTION
Hi,

this fixes bug when using running total with Discard/Paranoia. 
Running total of soft-deleted records is currently updated when value of delta_column is changed.