### PR TITLE
Replace initializing instance with checking instance_methods

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -23,7 +23,7 @@ module CounterCulture
           before_destroy :_update_counts_after_destroy, unless: :destroyed_for_counter_culture?
 
           if respond_to?(:before_real_destroy) &&
-              new.respond_to?(:paranoia_destroyed?)
+              instance_methods.include?(:paranoia_destroyed?)
             before_real_destroy :_update_counts_after_destroy,
               if: -> (model) { !model.paranoia_destroyed? }
           end


### PR DESCRIPTION
In our application `db:drop` was failing when the environment loaded a model that called `counter_culture`.  This was due to initializing a new instance which in turn hit the database.  See backtrace is at the bottom of this post.

The change in this PR accomplishes the same check without needing to initialize a brand new object which fixes our issue.  The issue in our app is pretty obscure and it would take me awhile to create a minimal reproducible test case.  However I believe this is a positive change in general since it decouples the `counter_culture` method from the model initialization process.

```
ActiveRecord::NoDatabaseError: FATAL:  database "test" does not exist
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:701:in `rescue in connect'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:697:in `connect'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:221:in `initialize'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:38:in `new'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/postgresql_adapter.rb:38:in `postgresql_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:759:in `new_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:803:in `checkout_new_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:782:in `try_to_checkout_new_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:743:in `acquire_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:500:in `checkout'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:374:in `connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:931:in `retrieve_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_handling.rb:116:in `retrieve_connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/connection_handling.rb:88:in `connection'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/model_schema.rb:471:in `load_schema!'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/attributes.rb:233:in `load_schema!'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/model_schema.rb:464:in `block in load_schema'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/model_schema.rb:461:in `load_schema'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/model_schema.rb:353:in `attribute_types'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/attribute_methods.rb:179:in `has_attribute?'
ruby/2.4.0/gems/activerecord-5.1.6.1/lib/active_record/inheritance.rb:55:in `new'
ruby/2.4.0/gems/counter_culture-2.1.2/lib/counter_culture/extensions.rb:34:in `counter_culture'
```
