### PR TITLE
Implement where option to Reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Product.counter_culture_fix_counts only: [[:subcategory, :category]]
 # will automatically fix counts only on the two-level [:subcategory, :category] relation on Product
 
 # :except and :only also accept arrays
+
+Product.counter_culture_fix_counts only: :category, where: { categories: { id: 1 } }
+# will automatically fix counts only on the :category with id 1 relation on Product
 ```
 
 The ```counter_culture_fix_counts``` counts method uses batch processing of records to keep the memory consumption low. The default batch size is 1000 but is configurable like so

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -81,7 +81,7 @@ module CounterCulture
           next if options[:exclude] && options[:exclude].include?(counter.relation)
           next if options[:only] && !options[:only].include?(counter.relation)
 
-          reconciler = CounterCulture::Reconciler.new(counter, options.slice(:skip_unsupported, :batch_size, :touch))
+          reconciler = CounterCulture::Reconciler.new(counter, options.slice(:skip_unsupported, :batch_size, :touch, :where))
           reconciler.reconcile!
           reconciler.changes
         end.compact

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -97,6 +97,8 @@ module CounterCulture
           # instances and we try to load all their counts at once
           batch_size = options.fetch(:batch_size, CounterCulture.config.batch_size)
 
+          counts_query = counts_query.where(options[:where])
+
           counts_query.group(full_primary_key(relation_class)).find_in_batches(batch_size: batch_size) do |records|
             # now iterate over all the models and see whether their counts are right
             update_count_for_batch(column_name, records)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1376,6 +1376,19 @@ describe "CounterCulture" do
     SimpleDependent.counter_culture_fix_counts :batch_size => A_BATCH
   end
 
+  it "should correctly fix the counter caches with conditionals" do
+    updated = SimpleMain.create
+    updated.simple_dependents.create
+    not_updated = SimpleMain.create
+    not_updated.simple_dependents.create
+    SimpleMain.all.update_all simple_dependents_count: 3
+
+    SimpleDependent.counter_culture_fix_counts only: :simple_main, where: { simple_mains: { id: updated.id } }
+
+    expect(updated.reload.simple_dependents_count).to eq(1)
+    expect(not_updated.reload.simple_dependents_count).to eq(3)
+  end
+
   it "should correctly fix the counter caches with thousands of records" do
     # first, clean up
     SimpleDependent.delete_all


### PR DESCRIPTION
to make it possible to limit the number of records which get updated.

For instance, we have quite a big number of records and running periodically on all records might not work so it would make sense to run periodically only on a subset of the records and schedule it to different times.

Does this make sense?