### PR TITLE
Use a MAX() aggregation when fetching current count during reconciliation

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -86,7 +86,12 @@ module CounterCulture
           relation_class_table_name = quote_table_name(relation_class.table_name)
 
           # select join column and count (from above) as well as cache column ('column_name') for later comparison
-          counts_query = scope.select("#{relation_class_table_name}.#{relation_class.primary_key}, #{relation_class_table_name}.#{relation_reflect(relation).association_primary_key(relation_class)}, #{count_select} AS count, #{relation_class_table_name}.#{column_name}")
+          counts_query = scope.select(
+            "#{relation_class_table_name}.#{relation_class.primary_key}, " \
+            "#{relation_class_table_name}.#{relation_reflect(relation).association_primary_key(relation_class)}, " \
+            "#{count_select} AS count, " \
+            "MAX(#{relation_class_table_name}.#{column_name}) AS #{column_name}"
+          )
 
           # we need to join together tables until we get back to the table this class itself lives in
           join_clauses(where).each do |join|

--- a/spec/models/has_non_pk_id.rb
+++ b/spec/models/has_non_pk_id.rb
@@ -1,0 +1,4 @@
+class HasNonPkId < ActiveRecord::Base
+  self.primary_key = :id
+  has_many :users
+end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
 
   default_scope do
     if _default_scope_enabled
-      query = joins("LEFT OUTER JOIN companies")
+      query = joins("LEFT OUTER JOIN companies ON users.company_id = companies.id")
       if Rails.version < "5.0.0"
         query = query.uniq
       else

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -3,8 +3,12 @@ class User < ActiveRecord::Base
 
   belongs_to :manages_company, :class_name => "Company"
   counter_culture :manages_company, :column_name => "managers_count"
+
   belongs_to :has_string_id
   counter_culture :has_string_id
+
+  belongs_to :has_non_pk_id
+  counter_culture :has_non_pk_id
 
   has_many :reviews
   accepts_nested_attributes_for :reviews, :allow_destroy => true

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "custom_delta_count",         :default => 0, :null => false
     t.integer  "review_approvals_count",      :default => 0, :null => false
     t.string   "has_string_id_id"
+    t.integer  "has_non_pk_id_id"
     t.float    "review_value_sum",    :default => 0.0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -91,6 +92,15 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "has_non_pk_ids", :force => true, :id => false do |t|
+    t.integer  "id", :default => '', :null => false
+    t.string   "something"
+    t.integer  "users_count",        :null => false, :default => 0
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+  add_index "has_non_pk_ids", :id, :unique => true
 
   create_table "has_string_ids", :force => true, :id => false do |t|
     t.string   "id", :default => '', :null => false


### PR DESCRIPTION
Fixes #253

On PostgreSQL, if the table where the counts are stored doesn't have a primary_key specified (in our case, because it's actually a view), reconciliation fails with an error:

```
PG::GroupingError:
   ERROR:  column "foo.users_count" must appear in the GROUP BY clause or be used in an aggregate function
   LINE 1: ...foo".id, COUNT("users".id)*1 AS count, "foo..
```

This is because, according to the [Postgres docs](https://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY):

> When GROUP BY is present, or any aggregate functions are present, it is not valid for the SELECT list expressions to refer to ungrouped columns except within aggregate functions or when the ungrouped column is functionally dependent on the grouped columns, since there would otherwise be more than one possible value to return for an ungrouped column. A functional dependency exists if the grouped columns (or a subset thereof) are the primary key of the table containing the ungrouped column.

When there's no primary key index present, even though Rails knows what the primary key is, no functional dependency gets detected at the DB level. 

This `MAX` agg should effectively be a no-op in every case, but it prevents PG from blowing up. An alternate fix to this same problem would be adding `"#{relation_class_table_name}.#{column_name}"` to the GROUP BY fields.

**Note:** the specs added in this commit will pass on SQLite even without these fixes — they work as expected when running the specs on a PostgreSQL DB. Running the tests on PG also reveals that the existing string ID specs (which also don't have a primary_key index) fail in the same way).