### PR TITLE
Do no print a newline after processing each batch in Reconciler

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -67,7 +67,7 @@ module CounterCulture
       end
 
       def perform
-        log "Performing reconciling of #{counter.model}##{counter.relation.to_sentence}.\n"
+        log "Performing reconciling of #{counter.model}##{counter.relation.to_sentence}."
         # if we're provided a custom set of column names with conditions, use them; just use the
         # column name otherwise
         # which class does this relation ultimately point to? that's where we have to start
@@ -105,14 +105,14 @@ module CounterCulture
             update_count_for_batch(column_name, records)
           end
         end
-        log "\n"
-        log "Finished reconciling of #{counter.model}##{counter.relation.to_sentence}.\n"
+        log_without_newline "\n"
+        log "Finished reconciling of #{counter.model}##{counter.relation.to_sentence}."
       end
 
       private
 
       def update_count_for_batch(column_name, records)
-        log "."
+        log_without_newline "."
 
         ActiveRecord::Base.transaction do
           records.each do |record|
@@ -143,6 +143,12 @@ module CounterCulture
         return unless log?
 
         Rails.logger.info(message)
+      end
+
+      def log_without_newline(message)
+        return unless log?
+
+        Rails.logger << message if Rails.logger.info?
       end
 
       def log?

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1367,13 +1367,17 @@ describe "CounterCulture" do
     SimpleDependent.delete_all
     SimpleMain.delete_all
 
-    main = SimpleMain.create
-    3.times { main.simple_dependents.create }
+    2.times do
+      main = SimpleMain.create
+      3.times { main.simple_dependents.create }
+    end
 
-    SimpleDependent.counter_culture_fix_counts :batch_size => A_BATCH, verbose: true
+    SimpleDependent.counter_culture_fix_counts :batch_size => 1, verbose: true
 
     expect(io.string).to include(
       "Performing reconciling of SimpleDependent#simple_main.")
+    expect(io.string).to include(
+      "..")
     expect(io.string).to include(
       "Finished reconciling of SimpleDependent#simple_main.")
     Rails.logger = logger


### PR DESCRIPTION
Hey @magnusvk,

in commit https://github.com/magnusvk/counter_culture/commit/5a74d3c611c9057058429aafe3cf88a68d48e112 unfortunately the logging of the reconciler got broken. The ``<<`` operation was used for a reason to not produce a new line after each batch gets processed, maybe this was not clear in my code 😢 

Currently this is was the reconciler logs in verbose mode:

```
I, [2019-04-16T10:20:24.578702 #33762]  INFO -- : Performing reconciling of SimpleDependent#simple_main.

I, [2019-04-16T10:20:24.646091 #33762]  INFO -- : .
I, [2019-04-16T10:20:24.646271 #33762]  INFO -- : 

I, [2019-04-16T10:20:24.646607 #33762]  INFO -- : Finished reconciling of SimpleDependent#simple_main.

```
See the additional empty lines as well as it prints the `.` after processing a batch on a new line. As it usually happens that MANY batches get processed, this will produce A LOT of new lines. I would like to have more an output like this:

```
I, [2019-04-16T10:18:20.691509 #33529]  INFO -- : Performing reconciling of SimpleDependent#simple_main.
..
I, [2019-04-16T10:18:20.760756 #33529]  INFO -- : Finished reconciling of SimpleDependent#simple_main.
```

See that the `..` gets printed on the same line. 

Hope this makes sense to you. Open for suggestions how to do it differently or improve the code submitted.

