### PR TITLE
Fix counter_culture option name of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ end
 class Membership < ActiveRecord::Base
   belongs_to :group
   belongs_to :member, class: "User"
-  counter_culture :group, column: "members_count"
+  counter_culture :group, column_name: "members_count"
   # If you'd like to also touch the group when `members_count` is updated
-  # counter_culture :group, column: "members_count", touch: true
+  # counter_culture :group, column_name: "members_count", touch: true
 end
 ```
 


### PR DESCRIPTION
I'm using it but option name is invalid.
So I fixed option name of Usage of README.md.