### PR TITLE
Duplicate decrement occurs under specific conditions (race condition bug)

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -20,7 +20,7 @@ module CounterCulture
           # initialize callbacks only once
           after_create :_update_counts_after_create
 
-          before_destroy :_update_counts_after_destroy, unless: :destroyed_for_counter_culture?
+          after_commit :_update_counts_after_destroy, on: :destroy, unless: :destroyed_for_counter_culture?
 
           if respond_to?(:before_real_destroy) &&
               instance_methods.include?(:paranoia_destroyed?)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -111,6 +111,35 @@ RSpec.describe "CounterCulture" do
     expect(product.reviews_count).to eq(0)
   end
 
+  it "does not duplicate decrements counter cache on destroy" do
+    user = User.create
+    product = Product.create
+
+    expect(user.reviews_count).to eq(0)
+    expect(product.reviews_count).to eq(0)
+    expect(user.review_approvals_count).to eq(0)
+
+    review = Review.create :user_id => user.id, :product_id => product.id, :approvals => 69
+    same_review = Review.find(review.id)
+
+    user.reload
+    product.reload
+
+    expect(user.reviews_count).to eq(1)
+    expect(product.reviews_count).to eq(1)
+    expect(user.review_approvals_count).to eq(69)
+
+    review.destroy
+    same_review.destroy
+
+    user.reload
+    product.reload
+
+    expect(user.reviews_count).to eq(0)
+    expect(user.review_approvals_count).to eq(0)
+    expect(product.reviews_count).to eq(0)
+  end
+
   it "updates counter cache on update" do
     user1 = User.create
     user2 = User.create

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe "CounterCulture" do
   end
 
   it "does not duplicate decrements counter cache on destroy" do
+    # NOTE: If Rails.version < 5.1.0, this test fails because rails bugs.
+    #       You should use Rails >= 5.1.0
+    next if Rails.version < "5.1.0"
+
     user = User.create
     product = Product.create
 


### PR DESCRIPTION
Thank you for a good library.

I have been suffering from a bug that the counter breaks.
The cause has not been identified, but I confirmed that the counter would break under certain conditions.

----

If users try to delete the same record by making DELETE requests at the same time, the counter will be decremented at the some times.
Please see [this commit](https://github.com/soranoba/counter_culture/commit/fe7d0fe1ac81012ece3779a6e3dcdab43afffdd9) and [result of CI](https://travis-ci.org/soranoba/counter_culture/builds/570116324).

This is because `destroy` (or `destroy!`) does not throw an exception if the record has already been deleted.
Also, `after_destroy` is called as many times as `destroy` (or `destroy!`) is executed, but `after_commit on: :destroy` is called as many times as it actually deletes. (In other words, it is called only once)

This eliminates race condition issues.


Thanks!!