### PR TITLE
Feature/round off values

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,31 @@ The value in the counter cache will be the sum of the ```weight_ounces``` values
 
 The ```:delta_column``` option supports all numeric column types, not just ```:integer```. Specifically, ```:float``` is supported and tested.
 
+#### Rounding off float values while totaling
+
+Following is a classic example of adding 2 float values resulting in recurring decimal points which are not rounded off.
+
+```ruby
+0.1 + 0.2
+=> 0.30000000000000004
+```
+
+Use the ```:precision``` option to round off values while totaling and updating the ```delta_column```.
+
+
+```ruby
+class Review < ActiveRecord::Base
+  belongs_to :user
+  counter_culture :user, column_name: 'review_value_sum', delta_column: 'value', precision: 2
+end
+
+class User < ActiveRecord::Base
+  has_many :reviews
+end
+```
+
+Now, the value in the counter cache will be sum of ```value``` with a precision of ```2```. In above example, result would be rounded off to ```0.3```.
+
 ### Dynamically over-writing affected foreign keys
 
 ```ruby

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1534,6 +1534,30 @@ RSpec.describe "CounterCulture" do
     expect(user.review_value_sum.round(1)).to eq(0)
   end
 
+  it "should correctly sum up float values with precision provided" do
+    user = User.create
+
+    r1 = Review.create :user_id => user.id, :value => 0.1
+
+    user.reload
+    expect(user.review_value_sum).to eq(0.1)
+
+    r2 = Review.create :user_id => user.id, :value => 0.2
+
+    user.reload
+    expect(user.review_value_sum).to eq(0.3)
+
+    r2.destroy
+
+    user.reload
+    expect(user.review_value_sum).to eq(0.1)
+
+    r1.destroy
+
+    user.reload
+    expect(user.review_value_sum).to eq(0)
+  end
+
   it "should correctly fix float values that came out of sync" do
     user = User.create
 

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -7,7 +7,7 @@ class Review < ActiveRecord::Base
   counter_culture :user
   counter_culture :user, :column_name => proc { |model| model.review_type && model.review_type != 'null' ? "#{model.review_type}_count" : nil }, :column_names => {"reviews.review_type = 'using'" => 'using_count', "reviews.review_type = 'tried'" => 'tried_count', "reviews.review_type = 'null'" => nil}
   counter_culture :user, :column_name => 'review_approvals_count', :delta_column => 'approvals'
-  counter_culture :user, :column_name => 'review_value_sum', :delta_column => 'value'
+  counter_culture :user, :column_name => 'review_value_sum', :delta_column => 'value', :precision => 2
   counter_culture :user, :column_name => 'dynamic_delta_count', delta_magnitude: proc {|model| model.weight }
   counter_culture :user, :column_name => 'custom_delta_count', delta_magnitude: 3
   counter_culture [:user, :manages_company]


### PR DESCRIPTION
We encountered a case where we were totalling float column and the resultant sum was not rounded off/out of precision e.g. `0.1 + 0.2` results in `0.30000000000000004` instead of `0.3`. Since `update_all` being used for updating the sum, AR callbacks were not helping either to format the data before updating.
Thus, I added an option `:precision` where one can provide the integer so as to specify number of decimal places for rounding off the sum.
I have added test cases as well, are all green and updated readme.

I believe it would be a good feature to have because, even though it can be rounded off while reading (as done in the test cases earlier), one might need to store the rounded values itself.

We are already using it in our code base and thought would be nice if other people can benefit from it.