### PR TITLE
Extend column_names option to accepting scope name as symbol hash key

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,20 +329,20 @@ class Product < ActiveRecord::Base
 end
 ```
 
-You can specify scope name instead of where condition string.
+You can specify scope instead of where condition string.
 
 ```ruby
 class Product < ActiveRecord::Base
   belongs_to :category
+  scope :awesomes, ->{ where "products.product_type = ?", 'awesome' }
+  scope :suckys, ->{ where "products.product_type = ?", 'sucky' }
+
   counter_culture :category,
       column_name: proc {|model| "#{model.product_type}_count" },
       column_names: {
-          awesomes: :awesome_count,
-          suckys: :sucky_count
+          Product.awesomes => :awesome_count,
+          Product.suckys => :sucky_count
       }
-  scope :awesomes, ->{ where "products.product_type = ?", 'awesome' }
-  scope :suckys, ->{ where "products.product_type = ?", 'sucky' }
-  # attribute product_type may be one of ['awesome', 'sucky']
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ class Product < ActiveRecord::Base
 end
 ```
 
+You can specify scope name instead of where condition string.
+
+```ruby
+class Product < ActiveRecord::Base
+  belongs_to :category
+  counter_culture :category,
+      column_name: proc {|model| "#{model.product_type}_count" },
+      column_names: {
+          awesomes: :awesome_count,
+          suckys: :sucky_count
+      }
+  scope :awesomes, ->{ where "products.product_type = ?", 'awesome' }
+  scope :suckys, ->{ where "products.product_type = ?", 'sucky' }
+  # attribute product_type may be one of ['awesome', 'sucky']
+end
+```
+
 If you would like to avoid this configuration and simply skip counter caches with
 dynamic column names, while still fixing those counters on the model that are not
 dynamic, you can pass `skip_unsupported`:

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -252,8 +252,8 @@ module CounterCulture
           if index == reverse_relation.size - 1
             # conditions must be applied to the join on which we are counting
             if where
-              if where.is_a? Symbol
-                joins_sql += " AND #{target_table_alias}.#{model.primary_key} IN (#{model.send(where).pluck(model.primary_key).join(',')})"
+              if where.respond_to?(:to_sql)
+                joins_sql += " AND #{target_table_alias}.#{model.primary_key} IN (#{where.select(model.primary_key).to_sql})"
               else
                 joins_sql += " AND (#{model.send(:sanitize_sql_for_conditions, where)})"
               end

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -252,7 +252,11 @@ module CounterCulture
           if index == reverse_relation.size - 1
             # conditions must be applied to the join on which we are counting
             if where
-              joins_sql += " AND (#{model.send(:sanitize_sql_for_conditions, where)})"
+              if where.is_a? Symbol
+                joins_sql += " AND #{target_table_alias}.#{model.primary_key} IN (#{model.send(where).pluck(model.primary_key).join(',')})"
+              else
+                joins_sql += " AND (#{model.send(:sanitize_sql_for_conditions, where)})"
+              end
             end
             # respect the deleted_at column if it exists
             if model.column_names.include?('deleted_at')

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2288,7 +2288,7 @@ RSpec.describe "CounterCulture" do
   end
 
   it "can fix counts by scope" do
-    prefecture = Prefecture.new name: 'Tokyo'
+    prefecture = Prefecture.new name: 'Tokyo', big_cities_count: 0
     prefecture.save!
     City.create!(name: 'Sibuya', prefecture: prefecture, population: 221800)
     City.create!(name: 'Oku Tama', prefecture: prefecture, population: 6045)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -29,6 +29,8 @@ require 'models/candidate_profile'
 require 'models/candidate'
 require 'models/with_module/model1'
 require 'models/with_module/model2'
+require 'models/prefecture'
+require 'models/city'
 
 require 'database_cleaner'
 DatabaseCleaner.strategy = :deletion
@@ -2283,6 +2285,17 @@ RSpec.describe "CounterCulture" do
       model2.reload
       expect(model2.model1s_count).to eq(5)
     end
+  end
+
+  it "can fix counts by scope" do
+    prefecture = Prefecture.new name: 'Tokyo'
+    prefecture.save!
+    City.create!(name: 'Sibuya', prefecture: prefecture, population: 221800)
+    City.create!(name: 'Oku Tama', prefecture: prefecture, population: 6045)
+
+    City.counter_culture_fix_counts
+
+    expect(prefecture.reload.big_cities_count).to eq(1)
   end
 
   private

--- a/spec/models/city.rb
+++ b/spec/models/city.rb
@@ -1,0 +1,15 @@
+class City < ActiveRecord::Base
+  belongs_to :prefecture
+
+  counter_culture(
+    :prefecture,
+    column_name:  ->(model) { model.big? ? :big_cities_count : nil },
+    column_names: { big: :big_cities_count }
+  )
+
+  scope :big, -> { where('population > ?', 100000) }
+
+  def big?
+    population > 100000
+  end
+end

--- a/spec/models/city.rb
+++ b/spec/models/city.rb
@@ -1,13 +1,12 @@
 class City < ActiveRecord::Base
   belongs_to :prefecture
+  scope :big, -> { where('population > ?', 100000) }
 
   counter_culture(
     :prefecture,
     column_name:  ->(model) { model.big? ? :big_cities_count : nil },
-    column_names: { big: :big_cities_count }
+    column_names: { City.big => :big_cities_count }
   )
-
-  scope :big, -> { where('population > ?', 100000) }
 
   def big?
     population > 100000

--- a/spec/models/prefecture.rb
+++ b/spec/models/prefecture.rb
@@ -1,0 +1,3 @@
+class Prefecture < ActiveRecord::Base
+  has_many :cities
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -252,4 +252,15 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   create_table :with_module_model2s, :force => true do |t|
     t.integer :model1s_count
   end
+
+  create_table :prefectures, :force => true do |t|
+    t.string :name
+    t.integer :big_cities_count, null: false, default: 0
+  end
+
+  create_table :cities, :force => true do |t|
+    t.string :name
+    t.integer :prefecture_id, null: false
+    t.integer :population, null: false
+  end
 end


### PR DESCRIPTION
Hello.
I extended column_names option whose hash key accepts scope names as symbol, inspired by #245.
When you apply counter to a model that has a complex condition, you can use this scope as column_names's condition instead of Arel or SQL-style condition.
