### PR TITLE
Add support for limits in batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,18 @@ Product.counter_culture_fix_counts verbose: true
 
 Product.counter_culture_fix_counts only: :category, where: { categories: { id: 1 } }
 # will automatically fix counts only on the :category with id 1 relation on Product
+
+Product.counter_culture_fix_counts start: 10_000
+# will fix counts for all counter caches defined on Product from record 10000 and onwards.
+
+Product.counter_culture_fix_counts finish: 10_000
+# let's process until 10000 records.
+
+Product.counter_culture_fix_counts start: 1000, finish: 2000
+# In worker 1, lets process from 1000 to 2000
+
+Product.counter_culture_fix_counts start: 2001, finish: 3000
+# In worker 1, lets process from 2001 to 3000
 ```
 
 The ```counter_culture_fix_counts``` counts method uses batch processing of records to keep the memory consumption low. The default batch size is 1000 but is configurable like so

--- a/README.md
+++ b/README.md
@@ -277,24 +277,6 @@ Product.counter_culture_fix_counts only: :category, where: { categories: { id: 1
 # will automatically fix counts only on the :category with id 1 relation on Product
 ```
 
-#### Parallelizing fix counter cache in multiple workers
-
-The options start and finish are especially useful if you want multiple workers dealing with the same processing queue. You can make worker 1 handle all the records between id 1 and 9999 and worker 2 handle from 10000 and beyond by setting the :start and :finish option on each worker.
-
-```ruby
-Product.counter_culture_fix_counts start: 10_000
-# will fix counts for all counter caches defined on Product from record 10000 and onwards.
-
-Product.counter_culture_fix_counts finish: 10_000
-# let's process until 10000 records.
-
-Product.counter_culture_fix_counts start: 1000, finish: 2000
-# In worker 1, lets process from 1000 to 2000
-
-Product.counter_culture_fix_counts start: 2001, finish: 3000
-# In worker 2, lets process from 2001 to 3000
-```
-
 The ```counter_culture_fix_counts``` counts method uses batch processing of records to keep the memory consumption low. The default batch size is 1000 but is configurable like so
 ```ruby
 # In an initializer
@@ -328,6 +310,25 @@ If you have specified a custom timestamps column, pass its name as the value for
 
 ```ruby
 Product.counter_culture_fix_counts touch: 'category_count_changed'
+```
+
+
+#### Parallelizing fix counter cache in multiple workers
+
+The options start and finish are especially useful if you want multiple workers dealing with the same processing queue. You can make worker 1 handle all the records between id 1 and 9999 and worker 2 handle from 10000 and beyond by setting the :start and :finish option on each worker.
+
+```ruby
+Product.counter_culture_fix_counts start: 10_000
+# will fix counts for all counter caches defined on Product from record 10000 and onwards.
+
+Product.counter_culture_fix_counts finish: 10_000
+# let's process until 10000 records.
+
+Product.counter_culture_fix_counts start: 1000, finish: 2000
+# In worker 1, lets process from 1000 to 2000
+
+Product.counter_culture_fix_counts start: 2001, finish: 3000
+# In worker 2, lets process from 2001 to 3000
 ```
 
 #### Handling dynamic column names

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Product.counter_culture_fix_counts start: 1000, finish: 2000
 # In worker 1, lets process from 1000 to 2000
 
 Product.counter_culture_fix_counts start: 2001, finish: 3000
-# In worker 1, lets process from 2001 to 3000
+# In worker 2, lets process from 2001 to 3000
 ```
 
 The ```counter_culture_fix_counts``` counts method uses batch processing of records to keep the memory consumption low. The default batch size is 1000 but is configurable like so

--- a/README.md
+++ b/README.md
@@ -275,7 +275,13 @@ Product.counter_culture_fix_counts verbose: true
 
 Product.counter_culture_fix_counts only: :category, where: { categories: { id: 1 } }
 # will automatically fix counts only on the :category with id 1 relation on Product
+```
 
+#### Parallelizing fix counter cache in multiple workers
+
+The options start and finish are especially useful if you want multiple workers dealing with the same processing queue. You can make worker 1 handle all the records between id 1 and 9999 and worker 2 handle from 10000 and beyond by setting the :start and :finish option on each worker.
+
+```ruby
 Product.counter_culture_fix_counts start: 10_000
 # will fix counts for all counter caches defined on Product from record 10000 and onwards.
 

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -81,7 +81,9 @@ module CounterCulture
           next if options[:exclude] && options[:exclude].include?(counter.relation)
           next if options[:only] && !options[:only].include?(counter.relation)
 
-          reconciler = CounterCulture::Reconciler.new(counter, options.slice(:skip_unsupported, :batch_size, :touch, :where, :verbose))
+          reconciler_options = %i(batch_size finish skip_unsupported start touch verbose where)
+
+          reconciler = CounterCulture::Reconciler.new(counter, options.slice(*reconciler_options))
           reconciler.reconcile!
           reconciler.changes
         end.compact

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -102,10 +102,12 @@ module CounterCulture
           # iterate in batches; otherwise we might run out of memory when there's a lot of
           # instances and we try to load all their counts at once
           batch_size = options.fetch(:batch_size, CounterCulture.config.batch_size)
+          start_index = options[:start]
+          finish_index = options[:finish]
 
-          counts_query = counts_query.where(options[:where])
+          counts_query = counts_query.where(options[:where]).group(full_primary_key(relation_class))
 
-          counts_query.group(full_primary_key(relation_class)).find_in_batches(batch_size: batch_size) do |records|
+          counts_query.find_in_batches(batch_size: batch_size, start: start_index, finish: finish_index) do |records|
             # now iterate over all the models and see whether their counts are right
             update_count_for_batch(column_name, records)
           end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2304,6 +2304,31 @@ RSpec.describe "CounterCulture" do
     expect(prefecture.reload.big_cities_count).to eq(1)
   end
 
+  it "support fix counts using batch limits start and finish" do
+    company = Company.create!
+    company.children << Company.create!
+    company.children_count = -1
+    company.save!
+
+    companies = 3.times.map do
+      company = Company.create!
+      company.children << Company.create!
+      company.children_count = -1
+      company.save!
+      company
+    end
+
+    start = companies.first.id
+    finish = companies.last.id
+
+    fixed = Company.counter_culture_fix_counts start: start, finish: finish
+    expect(fixed.length).to eq(3)
+
+    companies.each do |company|
+      expect(company.reload.children_count).to eq(1)
+    end
+  end
+
   private
   def papertrail_supported_here?
     return false if Rails.version < "5.0.0"

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2305,12 +2305,7 @@ RSpec.describe "CounterCulture" do
   end
 
   it "support fix counts using batch limits start and finish" do
-    company = Company.create!
-    company.children << Company.create!
-    company.children_count = -1
-    company.save!
-
-    companies = 3.times.map do
+    companies_group = 3.times.map do
       company = Company.create!
       company.children << Company.create!
       company.children_count = -1
@@ -2318,15 +2313,27 @@ RSpec.describe "CounterCulture" do
       company
     end
 
-    start = companies.first.id
-    finish = companies.last.id
+    company_out_of_first_group = Company.create!
+    company_out_of_first_group.children << Company.create!
+    company_out_of_first_group.children_count = -1
+    company_out_of_first_group.save!
+
+    start = companies_group.first.id
+    finish = companies_group.last.id
 
     fixed = Company.counter_culture_fix_counts start: start, finish: finish
     expect(fixed.length).to eq(3)
 
-    companies.each do |company|
+    companies_group.each do |company|
       expect(company.reload.children_count).to eq(1)
     end
+
+    expect(company_out_of_first_group.reload.children_count).to eq(-1)
+
+
+    Company.counter_culture_fix_counts start: company_out_of_first_group.id
+
+    expect(company_out_of_first_group.reload.children_count).to eq(1)
   end
 
   private

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2323,13 +2323,11 @@ RSpec.describe "CounterCulture" do
 
     fixed = Company.counter_culture_fix_counts start: start, finish: finish
     expect(fixed.length).to eq(3)
+    expect(company_out_of_first_group.reload.children_count).to eq(-1)
 
     companies_group.each do |company|
       expect(company.reload.children_count).to eq(1)
     end
-
-    expect(company_out_of_first_group.reload.children_count).to eq(-1)
-
 
     Company.counter_culture_fix_counts start: company_out_of_first_group.id
 


### PR DESCRIPTION
The options start and finish are especially useful if you want multiple workers dealing with the same processing queue. You can make worker 1 handle all the records between id 1 and 9999 and worker 2 handle from 10000 and beyond by setting the `:start` and `:finish` option on each worker.

Description is taken from [find_in_batches docs in rails](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_in_batches)

```ruby
Product.counter_culture_fix_counts start: 10_000
# will fix counts for all counter caches defined on Product from record 10000 and onwards.
Product.counter_culture_fix_counts finish: 10_000
# let's process until 10000 records.
Product.counter_culture_fix_counts start: 1000, finish: 2000
# In worker 1, lets process from 1000 to 2000
Product.counter_culture_fix_counts start: 2001, finish: 3000
# In worker 2, lets process from 2001 to 3000
```

Another use case of these options is to be able to restart the workers from specific id in case of failure in order to not revisit the records already processed 