### PR TITLE
Fix Rails version check in migration generator (Fixes #280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 2.3.0 (January 28, 2020)
 
 Improvements:
+  - Allow specifying `start` and `finish` options to `counter_culture_fix_counts` (#279)
+
+## 2.3.0 (January 28, 2020)
+
+Improvements:
   - Allow using scopes in `column_names` (#272)
 
 ## 2.2.4 (August 21, 2019)

--- a/counter_culture.gemspec
+++ b/counter_culture.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '> 2.0.0'
   spec.add_development_dependency 'awesome_print'
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'database_cleaner', '>= 1.1.1'
   spec.add_development_dependency 'discard'
   spec.add_development_dependency 'paper_trail'

--- a/lib/counter_culture/version.rb
+++ b/lib/counter_culture/version.rb
@@ -1,3 +1,3 @@
 module CounterCulture
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.4.0'.freeze
 end

--- a/lib/generators/counter_culture_generator.rb
+++ b/lib/generators/counter_culture_generator.rb
@@ -27,7 +27,7 @@ class CounterCultureGenerator < ActiveRecord::Generators::Base
   end
 
   def migration_version
-    if Rails.version.start_with? '5.'
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('5.0.0')
       "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
     end
   end


### PR DESCRIPTION
To include the Rails version not just for Rails 5.x but also future
versions.