### PR TITLE
Add read only attribute to test model

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -290,7 +290,7 @@ module CounterCulture
       changes_method = ACTIVE_RECORD_VERSION >= Gem::Version.new("5.1.0") ? :saved_changes : :changed_attributes
       obj.public_send(changes_method).each do |key, value|
         old_value = ACTIVE_RECORD_VERSION >= Gem::Version.new("5.1.0") ? value.first : value
-        prev.public_send("#{key}=", old_value)
+        prev[key] = old_value
       end
 
       prev

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -18,10 +18,15 @@ class Review < ActiveRecord::Base
   counter_culture [:user, :manages_company, :industry], :column_name => 'review_approvals_count', :delta_column => 'approvals'
 
   after_create :update_some_text
+  after_create :update_read_only_text
 
   def update_some_text
     return unless Gem::Version.new(Rails.version) >= Gem::Version.new('5.1.5')
     update_attribute(:some_text, rand(36**12).to_s(36))
+  end
+
+  def update_read_only_text
+    self[:read_only_text] = SecureRandom.uuid
   end
 
   def weight
@@ -30,5 +35,11 @@ class Review < ActiveRecord::Base
     else
       1
     end
+  end
+
+  private
+
+  def read_only_text=(*)
+    raise 'This is a read_only field'
   end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   create_table "reviews", :force => true do |t|
     t.string   "review_type",                :default => "using"
     t.string   "some_text"
+    t.string   "read_only_text"
     t.integer  "user_id"
     t.integer  "product_id"
     t.integer  "approvals"


### PR DESCRIPTION
I ran into the same problem as described in https://github.com/magnusvk/counter_culture/issues/278. First I've added a read only attribute to replicate the error in the test suite and then I changed the way the attributes are restored in the `previous_model` method. 

This way, it skips the overwritten setters which I think also makes sense to do since it's really the dirty changes as they will be persisted to the database. Aasm is also overwriting the setter and read only attributes are basically doing the same thing. I can't come up with a use case where this will not work but it's definitely good to think this trough. 

Closes https://github.com/magnusvk/counter_culture/issues/278