### PR TITLE
Print batch index logs

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -109,9 +109,11 @@ module CounterCulture
           find_in_batches_args[:start] = options[:start] if options[:start].present?
           find_in_batches_args[:finish] = options[:finish] if options[:finish].present?
 
-          counts_query.find_in_batches(find_in_batches_args) do |records|
+          counts_query.find_in_batches(find_in_batches_args).with_index(1) do |records, index|
+            log "Processing batch ##{index}."
             # now iterate over all the models and see whether their counts are right
             update_count_for_batch(column_name, records)
+            log "Finished batch ##{index}."
           end
         end
         log_without_newline "\n"
@@ -121,8 +123,6 @@ module CounterCulture
       private
 
       def update_count_for_batch(column_name, records)
-        log_without_newline "."
-
         ActiveRecord::Base.transaction do
           records.each do |record|
             count = record.read_attribute('count') || 0

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1410,7 +1410,13 @@ RSpec.describe "CounterCulture" do
     expect(io.string).to include(
       "Performing reconciling of SimpleDependent#simple_main.")
     expect(io.string).to include(
-      "..")
+      "Processing batch #1.")
+    expect(io.string).to include(
+      "Finished batch #1.")
+    expect(io.string).to include(
+      "Processing batch #2.")
+    expect(io.string).to include(
+      "Finished batch #2.")
     expect(io.string).to include(
       "Finished reconciling of SimpleDependent#simple_main.")
     Rails.logger = logger


### PR DESCRIPTION
Following up https://github.com/magnusvk/counter_culture/pull/279, when running multiple workers printing the batch index is useful information for not reprocessing same records, thanks to `start` and `finish` on `Model#counter_culture_fix_counts` we could restart from any point. In the following scenario, we know that we could restart the job from the last index processed by batch # 1

```
I, [2020-07-28T15:14:47.190722 #11698]  INFO -- : Performing reconciling of SimpleDependent#simple_main.
I, [2020-07-28T15:14:47.191807 #11698]  INFO -- : Processing batch #1.
I, [2020-07-28T15:14:47.191887 #11698]  INFO -- : Finshed batch #1.
I, [2020-07-28T15:14:47.192416 #11698]  INFO -- : Processing batch #2.
I, [2020-07-28T15:14:47.192416 #11698]  ERROR.....
```