### PR TITLE
added functionality

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -115,6 +115,11 @@ module CounterCulture
         counter_cache_name_was = counter.counter_cache_name_for(counter.previous_model(self))
         counter_cache_name = counter.counter_cache_name_for(self)
 
+        if counter.without_column_name && counter.column_names
+          counter_cache_name_was = counter.counter_cache_column_names_from_scope(counter.previous_model(self))
+          counter_cache_name = counter.counter_cache_column_names_from_scope(self)
+        end
+
         if counter.first_level_relation_changed?(self) ||
             (counter.delta_column && counter.attribute_changed?(self, counter.delta_column)) ||
             counter_cache_name != counter_cache_name_was

--- a/spec/models/city.rb
+++ b/spec/models/city.rb
@@ -1,14 +1,17 @@
 class City < ActiveRecord::Base
   belongs_to :prefecture
   scope :big, -> { where('population > ?', 100000) }
+  scope :small, -> { where('population < ?', 10000) }
+  scope :medium, -> { where('population > ? AND population < ?', 10000, 100000) }
+  scope :small_and_big_cities, -> { where('population > ? OR population < ?', 100000, 10000) }
 
   counter_culture(
     :prefecture,
-    column_name:  ->(model) { model.big? ? :big_cities_count : nil },
-    column_names: { City.big => :big_cities_count }
+    column_names: { 
+      City.big => :big_cities_count,
+      City.small => :small_cities_count,
+      City.medium => :medium_cities_count,
+      City.small_and_big_cities => :small_and_big_cities_count
+    }
   )
-
-  def big?
-    population > 100000
-  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -257,6 +257,9 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   create_table :prefectures, :force => true do |t|
     t.string :name
     t.integer :big_cities_count, null: false, default: 0
+    t.integer :small_cities_count, null: false, default: 0
+    t.integer :medium_cities_count, null: false, default: 0
+    t.integer :small_and_big_cities_count, null: false, default: 0
   end
 
   create_table :cities, :force => true do |t|


### PR DESCRIPTION
I added the possibilty to define only the column_names to easily create many counters using scopes. I know that the solution is not super neat, but that is because the previous_model is never part of the current scope so I had to calculate if the previous model would be part of the scope. This closes the issue #289 that I made. Most of the explanation is also in there what the code actually achieves