### PR TITLE
fixes last argument as keyword parameters deprecation warning

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -109,7 +109,7 @@ module CounterCulture
           find_in_batches_args[:start] = options[:start] if options[:start].present?
           find_in_batches_args[:finish] = options[:finish] if options[:finish].present?
 
-          counts_query.find_in_batches(find_in_batches_args).with_index(1) do |records, index|
+          counts_query.find_in_batches(**find_in_batches_args).with_index(1) do |records, index|
             log "Processing batch ##{index}."
             # now iterate over all the models and see whether their counts are right
             update_count_for_batch(column_name, records)


### PR DESCRIPTION
Thanks for creating this gem! It's super useful!

------------

On ruby 2.7.0, using the last argument as keyword parameters is deprecated (see [announcement](https://github.com/ruby/ruby/blob/4643bf5d55af6f79266dd67b69bb6eb4ff82029a/doc/NEWS-2.7.0#the-spec-of-keyword-arguments-is-changed-towards-30-)).

This PR fixes the following deprecation warning for ruby 2.7.1 on `lib/counter_culture/reconciler.rb:112`
```
counter_culture-2.6.0/lib/counter_culture/reconciler.rb:112: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```