### PR TITLE
[WIP] apply scope if available in polymorphic case

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -205,11 +205,15 @@ module CounterCulture
         # this is the column that stores the polymorphic type, aka the class name
         type_column = reflect.foreign_type.to_sym
         # so now turn that into the class that we're looking for here
-        if was
-          attribute_was(source, type_column).try(:constantize)
-        else
-          source.public_send(type_column).try(:constantize)
-        end
+        new_klass =
+          if was
+            attribute_was(source, type_column).try(:constantize)
+          else
+            source.public_send(type_column).try(:constantize)
+          end
+        return new_klass if reflect.scope.nil?
+        # in case of a scope is made available, merge it
+        new_klass.merge(reflect.scope)
       else
         reflect.klass
       end


### PR DESCRIPTION
I am encountering an issue with polymorphic associations having a defined scope, as follows:

```ruby
class Asset
  belongs_to :assetable, -> { unscope(where: :state) }, polymorphic: true
  counter_culture :assetable
end

class Project
  default_scope { where(state: 1) }
  has_many :assets, as: :assetable
end
```

The resulting query of the gem to update counters does not take into account the `unscope` statement.
I have quickly committed this fix to get your feedback and maybe go further with a complete PR.

Thanks for your help!