### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/counter_culture.gemspec
+++ b/counter_culture.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Turbo-charged counter caches for your Rails app.'
   spec.description   = 'counter_culture provides turbo-charged counter caches that are kept up-to-date not just on create and destroy, that support multiple levels of indirection through relationships, allow dynamic column names and that avoid deadlocks by updating in the after_commit callback.'
-  spec.homepage      = 'http://github.com/magnusvk/counter_culture'
+  spec.homepage      = 'https://github.com/magnusvk/counter_culture'
   spec.license       = 'MIT'
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/counter_culture or some tools or APIs that use the gem's metadata.