### PR TITLE
Remove dependency to after_commit_action gem

### DIFF
--- a/counter_culture.gemspec
+++ b/counter_culture.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'after_commit_action', '~> 1.0'
   spec.add_dependency 'activerecord', '>= 4.2'
   spec.add_dependency 'activesupport', '>= 4.2'
 

--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -1,4 +1,3 @@
-require 'after_commit_action'
 require 'active_support/concern'
 require 'active_support/lazy_load_hooks'
 

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -15,8 +15,6 @@ module CounterCulture
       # called to configure counter caches
       def counter_culture(relation, options = {})
         unless @after_commit_counter_cache
-          include AfterCommitAction unless include?(AfterCommitAction)
-
           # initialize callbacks only once
           after_create :_update_counts_after_create
 


### PR DESCRIPTION
`execute_after_commit` option has been removed in v2.0.0.