### PR TITLE
Add a column_name option for fixing counts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ Product.counter_culture_fix_counts only: :category
 Product.counter_culture_fix_counts only: [[:subcategory, :category]]
 # will automatically fix counts only on the two-level [:subcategory, :category] relation on Product
 
+Product.counter_culture_fix_counts column_name: :reviews_count
+# will automatically fix counts only on the :reviews_count column on Product
+# This allows us to skip the columns that have already been processed. This is useful after running big DB changes that affect only one counter cache column.
+
 # :except and :only also accept arrays
 
 Product.counter_culture_fix_counts verbose: true

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -59,7 +59,8 @@ module CounterCulture
       #
       # options:
       #   { :exclude => list of relations to skip when fixing counts,
-      #     :only => only these relations will have their counts fixed }
+      #     :only => only these relations will have their counts fixed,
+      #     :column_name => only this column will have its count fixed }
       # returns: a list of fixed record as an array of hashes of the form:
       #   { :entity => which model the count was fixed on,
       #     :id => the id of the model that had the incorrect count,
@@ -79,7 +80,7 @@ module CounterCulture
           next if options[:exclude] && options[:exclude].include?(counter.relation)
           next if options[:only] && !options[:only].include?(counter.relation)
 
-          reconciler_options = %i(batch_size finish skip_unsupported start touch verbose where)
+          reconciler_options = %i(batch_size column_name finish skip_unsupported start touch verbose where)
 
           reconciler = CounterCulture::Reconciler.new(counter, options.slice(*reconciler_options))
           reconciler.reconcile!

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -76,6 +76,10 @@ module CounterCulture
 
         counter_column_names = column_names || {nil => counter_cache_name}
 
+        if options[:column_name]
+          counter_column_names = counter_column_names.select{ |_, v| options[:column_name].to_s == v }
+        end
+
         # iterate over all the possible counter cache column names
         counter_column_names.each do |where, column_name|
           # if the column name is nil, that means those records don't affect


### PR DESCRIPTION
Add the support for the `column_name` option for `Model.counter_culture_fix_counts` to fix counts on the specific column. This allows us to skip the columns that have already been processed. This can be useful after running big DB changes that affect only one counter cache column.