### PR TITLE
Add attr_accessor to skip counts after create

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -2,6 +2,10 @@ module CounterCulture
   module Extensions
     extend ActiveSupport::Concern
 
+    included do
+      attr_accessor :skip_counts_after_create
+    end
+
     module ClassMethods
       # this holds all configuration data
       def after_commit_counter_cache
@@ -16,7 +20,7 @@ module CounterCulture
       def counter_culture(relation, options = {})
         unless @after_commit_counter_cache
           # initialize callbacks only once
-          after_create :_update_counts_after_create
+          after_create :_update_counts_after_create, unless: :skip_counts_after_create
 
           before_destroy :_update_counts_after_destroy, unless: :destroyed_for_counter_culture?
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -86,6 +86,24 @@ RSpec.describe "CounterCulture" do
     expect(product.reviews_count).to eq(1)
   end
 
+  it "skips increments counter cache on create" do
+    user = User.create
+    product = Product.create
+
+    expect(user.reviews_count).to eq(0)
+    expect(product.reviews_count).to eq(0)
+    expect(user.review_approvals_count).to eq(0)
+
+    user.reviews.create :user_id => user.id, :product_id => product.id, :approvals => 13, :skip_counts_after_create => true
+
+    user.reload
+    product.reload
+
+    expect(user.reviews_count).to eq(0)
+    expect(user.review_approvals_count).to eq(0)
+    expect(product.reviews_count).to eq(0)
+  end
+
   it "decrements counter cache on destroy" do
     user = User.create
     product = Product.create


### PR DESCRIPTION
I have a counter which gets triggered a lot on create (+-100 per second) which causes some performance issues.
I wanted to disable counter_culture on create and manually fix the count at a later stage.
I saw this issue: https://github.com/magnusvk/counter_culture/issues/299, but decided to implement it in a different way.
Please let me know if you are willing to add this to the gem. If so I can also update the readme.