### PR TITLE
Cache bundler dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+cache:
+  directories:
+     - ~/.rvm/gems
 services:
   - postgresql
   - mysql


### PR DESCRIPTION
Hi @magnusvk,

So the issue is because you customize the `install` phase in `.travis.yml` by explicitly updating dependencies (see [these lines](https://github.com/magnusvk/counter_culture/blob/3add9dfc6371c7610608b39b45788eaf51df118e/.travis.yml#L33-L36)), which makes them installed to a different directory `~/.rvm/gems` other than the default directory `vendor/bundle`. You may see [this](https://docs.travis-ci.com/user/caching/#caching-and-overriding-install-step) for reference. 

So now I've changed `cache` to point to the directory where gems are installed, and seems working. I restarted some jobs and I see that dependencies are being used from the cache. Thanks.