### PR TITLE
Added possibility to pass Procs to execute_after_commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ Another option is to simply defer the update of counter caches to outside of the
   counter_culture :category, execute_after_commit: true
 ```
 
+You can also pass a `Proc` for dynamic control. This is useful for temporarily enabling realtime counters:
+
+```ruby
+  counter_culture :category, execute_after_commit: proc { !Thread.current[:realtime_counter] }
+```
+
 ### Manually populating counter cache values
 
 You will sometimes want to populate counter-cache values from primary data. This is required when adding counter-caches to existing data. It is also recommended to run this regularly (at BestVendor, we run it once a week) to catch any incorrect values in the counter caches.

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -311,7 +311,9 @@ module CounterCulture
     end
 
     def execute_now_or_after_commit(obj, &block)
-      if @execute_after_commit
+      execute_after_commit = @execute_after_commit.is_a?(Proc) ? @execute_after_commit.call : @execute_after_commit
+
+      if execute_after_commit
         obj.execute_after_commit(&block)
       else
         block.call

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -10,4 +10,8 @@ class Post < ActiveRecord::Base
     :with_papertrail => PapertrailSupport.supported_here?
 
   counter_culture [:subcateg, :categ]
+
+  counter_culture :subcateg, :column_name => :posts_dynamic_commit_count,
+    :execute_after_commit => proc { !Thread.current[:realtime_counter] },
+    :with_papertrail => PapertrailSupport.supported_here?
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "fk_cat_id"
     t.integer  "posts_count",       :default => 0, :null => false
     t.integer  "posts_after_commit_count",       :default => 0, :null => false
+    t.integer  "posts_dynamic_commit_count",       :default => 0, :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,15 @@ module PapertrailSupport
   end
 end
 
+module DynamicAfterCommit
+  def self.with_realtime_counters(&block)
+    Thread.current[:realtime_counter] = true
+    yield
+  ensure
+    Thread.current[:realtime_counter] = nil
+  end
+end
+
 require 'rspec'
 require 'timecop'
 


### PR DESCRIPTION
This is useful to temporarily allow real-time counter updates in a controlled scope.

Example:

```ruby
  # models/comment.rb
  counter_culture :post, execute_after_commit: proc { !Thread.current[:realtime_counter] }
```

```ruby
  Post.transaction do
    post = Post.lock.last
    with_realtime_counters do
      post.comments.last.destroy!
    end
  end
  
  def with_realtime_counters(&block)
    Thread.current[:realtime_counter] = true
    yield
  ensure
    Thread.current[:realtime_counter] = nil
  end
```