### PR TITLE
Allows providing a Proc to column_names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,9 @@ class Product < ActiveRecord::Base
 end
 ```
 
-You can specify a scope instead of a where condition string for `column_names`:
+You can specify a scope instead of a where condition string for `column_names`. It is recommended
+to provide a Proc that returns a hash instead of directly providing a hash as the scope
+will hit your database to load the schema cache while your model is being loaded:
 
 ```ruby
 class Product < ActiveRecord::Base
@@ -364,10 +366,10 @@ class Product < ActiveRecord::Base
 
   counter_culture :category,
       column_name: proc {|model| "#{model.product_type}_count" },
-      column_names: {
+      column_names: -> { {
           Product.awesomes => :awesome_count,
           Product.suckys => :sucky_count
-      }
+      } }
 end
 ```
 

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -45,8 +45,9 @@ module CounterCulture
           @after_commit_counter_cache = []
         end
 
-        if options[:column_names] && !options[:column_names].is_a?(Hash)
-          raise ":column_names must be a Hash of conditions and column names"
+        if options[:column_names] && !(options[:column_names].is_a?(Hash) || options[:column_names].is_a?(Proc))
+          raise ":column_names must be a Hash of conditions and column names, " \
+                "or a Proc that when called returns such a Hash"
         end
 
         # add the counter to our collection

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -74,7 +74,17 @@ module CounterCulture
 
         scope = relation_class
 
-        counter_column_names = column_names || {nil => counter_cache_name}
+        counter_column_names =
+          case column_names
+          when Proc
+            column_names.call
+          when Hash
+            column_names
+          else
+            { nil => counter_cache_name }
+          end
+
+        raise ArgumentError, "The result of :column_names must return a Hash" unless counter_column_names.is_a?(Hash)
 
         if options[:column_name]
           counter_column_names = counter_column_names.select{ |_, v| options[:column_name].to_s == v }

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2306,21 +2306,41 @@ RSpec.describe "CounterCulture" do
     end
   end
 
-  it "can fix counts by scope" do
-    prefecture = Prefecture.new name: 'Tokyo'
-    prefecture.save!
-    City.create!(name: 'Sibuya', prefecture: prefecture, population: 221800)
-    City.create!(name: 'Oku Tama', prefecture: prefecture, population: 6045)
+  describe "fix counts by scope" do
+    let(:prefecture) { Prefecture.new name: 'Tokyo' }
 
-    prefecture.reload
-    expect(prefecture.big_cities_count).to eq(1)
+    before do
+      prefecture.save!
+      City.create!(name: 'Sibuya', prefecture: prefecture, population: 221800)
+      City.create!(name: 'Oku Tama', prefecture: prefecture, population: 6045)
 
-    prefecture.big_cities_count = 999
-    prefecture.save!
+      prefecture.reload
+    end
 
-    City.counter_culture_fix_counts
+    context "when column_names is a Hash" do
+      it "can fix counts by scope" do
+        expect(prefecture.big_cities_count).to eq(1)
 
-    expect(prefecture.reload.big_cities_count).to eq(1)
+        prefecture.big_cities_count = 999
+        prefecture.save!
+
+        City.counter_culture_fix_counts
+        expect(prefecture.reload.big_cities_count).to eq(1)
+      end
+    end
+
+    context "when column_names is a Proc" do
+      it "can fix counts by scope" do
+        expect(prefecture.small_cities_count).to eq(1)
+
+        prefecture.small_cities_count = 999
+        prefecture.save!
+
+        City.counter_culture_fix_counts
+
+        expect(prefecture.reload.small_cities_count).to eq(1)
+      end
+    end
   end
 
   it "support fix counts using batch limits start and finish" do

--- a/spec/models/city.rb
+++ b/spec/models/city.rb
@@ -1,6 +1,7 @@
 class City < ActiveRecord::Base
   belongs_to :prefecture
   scope :big, -> { where('population > ?', 100000) }
+  scope :small, -> { where('population <= ?', 100000) }
 
   counter_culture(
     :prefecture,
@@ -8,7 +9,17 @@ class City < ActiveRecord::Base
     column_names: { City.big => :big_cities_count }
   )
 
+  counter_culture(
+    :prefecture,
+    column_name:  ->(model) { model.small? ? :small_cities_count : nil },
+    column_names: -> { { City.small => :small_cities_count } }
+  )
+
   def big?
     population > 100000
+  end
+
+  def small?
+    !big?
   end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -257,6 +257,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   create_table :prefectures, :force => true do |t|
     t.string :name
     t.integer :big_cities_count, null: false, default: 0
+    t.integer :small_cities_count, null: false, default: 0
   end
 
   create_table :cities, :force => true do |t|


### PR DESCRIPTION
* Returning a direct hash with a scope triggers loading of the schema cache in ActiveRecord, which can be undesirable
when your app is being booted. Using a Proc instead defers hitting this scope until it is actually called.

Fixes https://github.com/magnusvk/counter_culture/issues/298

It is discouraged to hit your database while code is being loaded during the boot process, this can affect such tasks as `db:create`, or building a Docker image that doesn't have access to a database. We can just use a Proc so the scope isn't called until it's actually needed.