### PR TITLE
Allow specifying the polymorphic_classes when calling counter_culture_fix_counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0 (December 28, 2021)
+
+Improvements:
+  - Allow specifiying `polymorphic_classes` to avoid a potentially expensive
+    `DISTINCT` query when calling `counter_culture_fix_counts` (#336)
+
 ## 3.1.0 (November 29, 2021)
 
 Improvements:

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ end
 
 You can specify a scope instead of a where condition string for `column_names`. We recommend
 providing a Proc that returns a hash instead of directly providing a hash: If you were to directly
-provide a scope this would load your schema cache on startup which will break things like 
+provide a scope this would load your schema cache on startup which will break things like
 `rake db:migrate`.
 
 ```ruby
@@ -458,6 +458,17 @@ end
 #### Polymorphic associations
 
 counter_culture now supports polymorphic associations of one level only.
+
+To discover which models need to be updated via `counter_culture_fix_counts`,
+counter_culture performs a `DISTINCT` query on the polymorphic relationship.
+This query can be expensive so we therefore offer the option
+(`polymorphic_classes`) to specify the models' counts that should be corrected:
+
+```ruby
+Image.counter_culture_fix_counts(polymorphic_classes: Product)
+# or
+Image.counter_culture_fix_counts(polymorphic_classes: [Product, Employee])
+```
 
 ## Contributing to counter_culture
 

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -71,7 +71,8 @@ module CounterCulture
       # options:
       #   { :exclude => list of relations to skip when fixing counts,
       #     :only => only these relations will have their counts fixed,
-      #     :column_name => only this column will have its count fixed }
+      #     :column_name => only this column will have its count fixed
+      #     :polymorphic_classes => specify the class(es) to update in polymorphic associations }
       # returns: a list of fixed record as an array of hashes of the form:
       #   { :entity => which model the count was fixed on,
       #     :id => the id of the model that had the incorrect count,
@@ -91,7 +92,7 @@ module CounterCulture
           next if options[:exclude] && options[:exclude].include?(counter.relation)
           next if options[:only] && !options[:only].include?(counter.relation)
 
-          reconciler_options = %i(batch_size column_name finish skip_unsupported start touch verbose where)
+          reconciler_options = %i(batch_size column_name finish skip_unsupported start touch verbose where polymorphic_classes)
 
           reconciler = CounterCulture::Reconciler.new(counter, options.slice(*reconciler_options))
           reconciler.reconcile!

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -28,7 +28,7 @@ module CounterCulture
         raise "Fixing counter caches is not supported when :delta_magnitude is a Proc; you may skip this relation with :skip_unsupported => true" if delta_magnitude.is_a?(Proc)
       end
 
-      associated_model_classes.each do |associated_model_class|
+      Array(associated_model_classes).each do |associated_model_class|
         Reconciliation.new(counter, changes, options, associated_model_class).perform
       end
 
@@ -39,7 +39,7 @@ module CounterCulture
 
     def associated_model_classes
       if polymorphic?
-        polymorphic_associated_model_classes
+        options[:polymorphic_classes].presence || polymorphic_associated_model_classes
       else
         [associated_model_class]
       end

--- a/lib/counter_culture/version.rb
+++ b/lib/counter_culture/version.rb
@@ -1,3 +1,3 @@
 module CounterCulture
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.2.0'.freeze
 end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2186,6 +2186,30 @@ RSpec.describe "CounterCulture" do
         expect(employee.reload.poly_images_count).to eq(2)
       end
 
+      it "can fix counts for a specified polymorphic correctly" do
+        2.times { PolyImage.create(imageable: employee) }
+        1.times { PolyImage.create(imageable: product1) }
+        mess_up_counts
+
+        PolyImage.counter_culture_fix_counts(polymorphic_classes: PolyEmployee)
+
+        expect(product1.reload.poly_images_count_dup).to eq(100) # unchanged
+        expect(employee.reload.poly_images_count_dup).to eq(2)
+      end
+
+      it "can fix counts for multiple specified polymorphics correctly" do
+        2.times { PolyImage.create(imageable: employee) }
+        1.times { PolyImage.create(imageable: product1) }
+        mess_up_counts
+
+        PolyImage.counter_culture_fix_counts(
+          polymorphic_classes: [PolyEmployee, PolyProduct]
+        )
+
+        expect(product1.reload.poly_images_count_dup).to eq(1)
+        expect(employee.reload.poly_images_count_dup).to eq(2)
+      end
+
       it "can handle nil values" do
         img = PolyImage.create(imageable: employee)
         PolyImage.create(imageable: nil)


### PR DESCRIPTION
### What

Provides the option of specifying the `polymorphic_classes` when calling `counter_culture_fix_counts`

### Why

I discovered that the `DISTINCT` query used in polymorphic relationships could be very expensive on large tables. The screenshot below shows that the majority of time spent in order creation on our marketplace platform is from this query.

![image](https://user-images.githubusercontent.com/2565158/147580790-639015f9-a3ab-49e1-9381-430b535790cd.png)

The result of the query is the name of the classes to be updated. It's common in our use cases, [here at Patch](https://www.patch.io/), that we know the associated model or models that need to be updated. Therefore, providing this option will eliminate the potentially expensive query. All existing behavior is preserved.

### Notes

This change is live in production on our fork of the repo. I used [db-query-matchers](https://github.com/civiccc/db-query-matchers) to confirm the fix when testing locally.