### PR TITLE
Fix primary key name for enumerable relations

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -165,7 +165,7 @@ module CounterCulture
     def foreign_key_value(obj, relation, was = false)
       original_relation = relation
       relation = relation.is_a?(Enumerable) ? relation.dup : [relation]
-      first_relation = relation.first
+      
       if was
         first = relation.shift
         foreign_key_value = attribute_was(obj, relation_foreign_key(first))

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -163,6 +163,7 @@ module CounterCulture
     #   pass true to get the past value, false or nothing to get the
     #   current value
     def foreign_key_value(obj, relation, was = false)
+      original_relation = relation
       relation = relation.is_a?(Enumerable) ? relation.dup : [relation]
       first_relation = relation.first
       if was
@@ -180,7 +181,8 @@ module CounterCulture
       while !value.nil? && relation.size > 0
         value = value.send(relation.shift)
       end
-      return value.try(relation_primary_key(first_relation, source: obj, was: was).try(:to_sym))
+
+      return value.try(relation_primary_key(original_relation, source: obj, was: was).try(:to_sym))
     end
 
     # gets the reflect object on the given relation

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -31,6 +31,9 @@ require 'models/with_module/model1'
 require 'models/with_module/model2'
 require 'models/prefecture'
 require 'models/city'
+require 'models/group'
+require 'models/sub_group'
+require 'models/group_item'
 
 if ENV['DB'] == 'postgresql'
   require 'models/purchase_order'
@@ -1389,6 +1392,16 @@ RSpec.describe "CounterCulture" do
     string_id2.reload
     expect(string_id.users_count).to eq(0)
     expect(string_id2.users_count).to eq(0)
+  end
+
+  it 'should work with different primary keys when relation is an array' do
+    group = Group.create
+    sub_group = SubGroup.create(group: group)
+
+    expect(group.group_items_count).to eq(0)
+    group_item = GroupItem.create(sub_group: sub_group)
+
+    expect(group.reload.group_items_count).to eq(1)    
   end
 
   it "should raise a good error message when calling fix_counts with no caches defined" do

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1394,14 +1394,30 @@ RSpec.describe "CounterCulture" do
     expect(string_id2.users_count).to eq(0)
   end
 
-  it 'should work with different primary keys when relation is an array' do
-    group = Group.create
-    sub_group = SubGroup.create(group: group)
+  context "when relation is an array but has different primary keys along the chain" do
+    it "should update correctly" do
+      group = Group.create
+      sub_group = SubGroup.create(group: group)
 
-    expect(group.group_items_count).to eq(0)
-    group_item = GroupItem.create(sub_group: sub_group)
+      expect(group.group_items_count).to eq(0)
+      group_item = GroupItem.create(sub_group: sub_group)
 
-    expect(group.reload.group_items_count).to eq(1)    
+      expect(group.reload.group_items_count).to eq(1)
+    end
+
+    it "should fix counts correctly" do
+      group = Group.create
+      sub_group = SubGroup.create(group: group)
+      group_item = GroupItem.create(sub_group: sub_group)
+
+      expect(group.reload.group_items_count).to eq(1)
+
+      group.update!(group_items_count: -1)
+
+      GroupItem.counter_culture_fix_counts
+
+      expect(group.reload.group_items_count).to eq(1)
+    end
   end
 
   it "should raise a good error message when calling fix_counts with no caches defined" do

--- a/spec/models/group.rb
+++ b/spec/models/group.rb
@@ -1,0 +1,3 @@
+class Group < ActiveRecord::Base
+  has_many :sub_groups
+end

--- a/spec/models/group_item.rb
+++ b/spec/models/group_item.rb
@@ -1,0 +1,4 @@
+class GroupItem < ActiveRecord::Base
+  counter_culture %i[sub_group group]
+  belongs_to :sub_group, foreign_key: 'sub_group_uuid'
+end

--- a/spec/models/sub_group.rb
+++ b/spec/models/sub_group.rb
@@ -1,0 +1,8 @@
+class SubGroup < ActiveRecord::Base
+  has_many :group_items, foreign_key: 'sub_group_uuid'
+  belongs_to :group
+
+  before_create do
+    self.uuid = SecureRandom.uuid
+  end
+end

--- a/spec/models/sub_group.rb
+++ b/spec/models/sub_group.rb
@@ -1,4 +1,6 @@
 class SubGroup < ActiveRecord::Base
+  self.primary_key = "uuid"
+
   has_many :group_items, foreign_key: 'sub_group_uuid'
   belongs_to :group
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -268,6 +268,18 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer :population, null: false
   end
 
+  create_table "groups", :force => true do |t|
+    t.integer  "group_items_count", :default => 0, :null => false
+  end
+
+  create_table "sub_groups", primary_key: 'uuid', id: :uuid, :force => true do |t|
+    t.integer  "group_id", :null => false
+  end
+
+  create_table "group_items", :force => true do |t|
+    t.string  "sub_group_uuid", :null => false
+  end
+
   if ENV['DB'] == 'postgresql' && Gem::Version.new(Rails.version) >= Gem::Version.new('5.0')
     create_table :purchase_orders, :force => true do |t|
       t.money "total_amount", scale: 2, default: "0.0", null: false

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -272,7 +272,8 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "group_items_count", :default => 0, :null => false
   end
 
-  create_table "sub_groups", primary_key: 'uuid', id: :uuid, :force => true do |t|
+  create_table "sub_groups", primary_key: 'uuid', id: false, :force => true do |t|
+    t.string  "uuid", :null => false
     t.integer  "group_id", :null => false
   end
 


### PR DESCRIPTION
This fixes an issue that happens when you have an array of relations, such as `[:sub_group, :group]` and their id keys are different. For example, one id key is `id` and another one is `uuid` or `uid` or anything else.

Before this fix, the method would `try` to access the last relation id using a previous relation key.