### PR TITLE
Fix bug on counter_culture_fix_counts when column_name is a symbol

### DIFF
--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -85,7 +85,9 @@ module CounterCulture
           end
 
         if options[:column_name]
-          counter_column_names = counter_column_names.select{ |_, v| options[:column_name].to_s == v }
+          counter_column_names = counter_column_names.select do |_, v|
+            options[:column_name].to_s == v.to_s
+          end
         end
 
         # iterate over all the possible counter cache column names

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2547,6 +2547,19 @@ RSpec.describe "CounterCulture" do
       )
     end
 
+    context "when column_names value is a Symbol" do
+      before do
+        prefecture.update_columns(big_cities_count: 0, small_cities_count: 0)
+      end
+
+      it "updates the column" do
+        expect(prefecture.reload.big_cities_count).to be(0)
+        City.counter_culture_fix_counts(only: :prefecture,
+                                        column_name: :big_cities_count)
+        expect(prefecture.reload.big_cities_count).to be(1)
+      end
+    end
+
     context "when column_names is a Hash" do
       it "can fix counts by scope" do
         expect(prefecture.big_cities_count).to eq(1)


### PR DESCRIPTION
Hi all 👋 

I believe I've come across a bug. This PR should fix it.

## The problem

When using the `column_name` option on `counter_culture_fix_counts`, I wasn't seeing any changes to my column when the column name was dynamic (configured using the `column_names` option in my model).

On closer inspection, the problem only seemed to occur when I used a symbol to define the column name in the `column_names` hash. When I used a string, it worked as expected.  (Examples in the README use symbols).

## The solution

I've patched this by simply ensuring that the column_name comparison in `Reconciler` is comparing String to String.

## Example code

``` ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "activerecord", require: "active_record"
  gem "sqlite3"
  gem "counter_culture"
end


ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.connection.instance_eval do
  create_table(:categories) do |t|
    t.string :name, null: false
    t.integer :awesome_count, null: false, default: 0
    t.integer :sucky_count, null: false, default: 0
  end
  create_table(:products) do |t|
    t.string :name, null: false
    t.string :product_type, null: false
    t.integer :category_id, null: false
  end
end
class Category < ActiveRecord::Base
  has_many :products
end

# Taken from README
class Product < ActiveRecord::Base
  belongs_to :category
  scope :awesomes, ->{ where "products.product_type = ?", 'awesome' }
  scope :suckys, ->{ where "products.product_type = ?", 'sucky' }

  counter_culture :category,
      column_name: proc {|model| "#{model.product_type}_count" },
      column_names: -> { {
          Product.awesomes => :awesome_count, # <= this wouldn't update
          Product.suckys => "sucky_count"  # <= this works as expected
      } }
end

# Set up some test records...
toys = Category.create!(name: "Toys")
Product.create!(name: "Meccano", product_type: "sucky", category: toys)
Product.create!(name: "Lego", product_type: "awesome", category: toys)

# Reset counters ...
toys.update_columns(awesome_count: 0, sucky_count: 0)

# Update counters...
Product.counter_culture_fix_counts(only: :category, column_name: "awesome_count")
Product.counter_culture_fix_counts(only: :category, column_name: "sucky_count")
# Demonstrates the issue:
puts Category.first.inspect
# => #<Category id: 1, name: "Toys", awesome_count: 0, sucky_count: 1>
# Both counters should have been updated, but only :sucky_count was, since it was defined using a String 
```
