### PR TITLE
Fix issue that decrement counter cache is called multiple times

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -113,8 +113,10 @@ module CounterCulture
     # called by after_destroy callback
     def _update_counts_after_destroy
       self.class.after_commit_counter_cache.each do |counter|
-        # decrement counter cache
-        counter.change_counter_cache(self, :increment => false)
+        unless destroyed?
+          # decrement counter cache
+          counter.change_counter_cache(self, :increment => false)
+        end
       end
     end
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -123,6 +123,16 @@ RSpec.describe "CounterCulture" do
     expect(user.reviews_count).to eq(0)
     expect(user.review_approvals_count).to eq(0)
     expect(product.reviews_count).to eq(0)
+
+    # this does not decrement counter cache
+    review.destroy
+
+    user.reload
+    product.reload
+
+    expect(user.reviews_count).to eq(0)
+    expect(user.review_approvals_count).to eq(0)
+    expect(product.reviews_count).to eq(0)
   end
 
   it "updates counter cache on update" do


### PR DESCRIPTION
For example, there are these models.

```ruby
class Book < ApplicationRecord
  has_many :reviews
end

class Review < ApplicationRecord
  belongs_to :book
  counter_culture :book
end
```

I called review.destory method twice. I expected this decrements counter -1. But, this decrements counter -2 acutually.
I fixed it.

```ruby
book = Book.create
review = Review.create(book: book)

book.reload
expect(book.reviews_count).to eq 1

review.destroy
book.reload
expect(book.reviews_count).to eq 0

review.destroy
book.reload
expect(book.reviews_count).to eq 0 # actually, -1 
```