### PR TITLE
Fix passing a proc to `column_names`

### DIFF
--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -45,15 +45,7 @@ module CounterCulture
           @after_commit_counter_cache = []
         end
 
-        column_names_valid = (
-          !options[:column_names] ||
-          options[:column_names].is_a?(Hash) ||
-          (
-            options[:column_names].is_a?(Proc) &&
-            options[:column_names].call.is_a?(Hash)
-          )
-        )
-        unless column_names_valid
+        if options[:column_names] && !(options[:column_names].is_a?(Hash) || options[:column_names].is_a?(Proc))
           raise ArgumentError.new(
             ":column_names must be a Hash of conditions and column names, " \
             "or a Proc that when called returns such a Hash"

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -84,6 +84,8 @@ module CounterCulture
             { nil => counter_cache_name }
           end
 
+        raise ArgumentError, ":column_names must be a Hash of conditions and column names" unless counter_column_names.is_a?(Hash)
+
         if options[:column_name]
           counter_column_names = counter_column_names.select do |_, v|
             options[:column_name].to_s == v.to_s

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2573,6 +2573,13 @@ RSpec.describe "CounterCulture" do
     end
 
     context "when column_names is a Proc" do
+      it "does not call the proc right away" do
+        called = false
+        City.counter_culture :prefecture, column_name: :foo,
+             column_names: -> { called = true; :foo }
+        expect(called).to eq(false)
+      end
+
       it "can fix counts by scope" do
         expect(prefecture.small_cities_count).to eq(1)
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2573,16 +2573,6 @@ RSpec.describe "CounterCulture" do
     end
 
     context "when column_names is a Proc" do
-      it "raises an error when the Proc doesn't return a hash" do
-        expect {
-          City.counter_culture :prefecture, column_name: :foo,
-            column_names: -> { :foo }
-        }.to raise_error(
-          ArgumentError,
-          ":column_names must be a Hash of conditions and column names, or a Proc that when called returns such a Hash",
-        )
-      end
-
       it "can fix counts by scope" do
         expect(prefecture.small_cities_count).to eq(1)
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2573,11 +2573,21 @@ RSpec.describe "CounterCulture" do
     end
 
     context "when column_names is a Proc" do
-      it "does not call the proc right away" do
-        called = false
-        City.counter_culture :prefecture, column_name: :foo,
-             column_names: -> { called = true; :foo }
-        expect(called).to eq(false)
+      context "when the return value is not a hash" do
+        it "does not call the proc right away" do
+          called = false
+          City.counter_culture :prefecture, column_name: :big_cities_count,
+               column_names: -> { called = true; :foo }
+          expect(called).to eq(false)
+        end
+
+        it "raises an error when called later" do
+          City.counter_culture :prefecture, column_name: :big_cities_count,
+               column_names: -> { :foo }
+          expect { City.counter_culture_fix_counts }.to raise_error(
+            ":column_names must be a Hash of conditions and column names"
+          )
+        end
       end
 
       it "can fix counts by scope" do


### PR DESCRIPTION
The documentation states

> You can specify a scope instead of a where condition string for `column_names`. We recommend
providing a Proc that returns a hash instead of directly providing a hash: If you were to directly
provide a scope this would load your schema cache on startup which will break things like
`rake db:migrate`.

This doesn't work tho as the proc is immediately `call`-ed in the `counter_culture` method to check it's return value. To fix this I've moved the ArgumentError from the setup side to the runtime side.