### PR TITLE
added example when removed from habtm relation

### DIFF
--- a/spec/models/habtm_category.rb
+++ b/spec/models/habtm_category.rb
@@ -1,0 +1,4 @@
+class HabtmCategory < ActiveRecord::Base
+  has_many :habtm_categories_products
+  has_many :habtm_products, through: :habtm_categories_products, class_name: 'HabtmProduct'
+end

--- a/spec/models/habtm_category_product.rb
+++ b/spec/models/habtm_category_product.rb
@@ -1,0 +1,11 @@
+class HabtmCategoriesProduct < ActiveRecord::Base
+  belongs_to :habtm_product
+  belongs_to :habtm_category
+
+  counter_culture :habtm_category,
+                  column_name: ->(model) { model.habtm_product.visible? ? 'products_count' : nil },
+                  column_names: {
+                    HabtmProduct.visible => 'products_count'
+                  },
+                  touch: true
+end

--- a/spec/models/habtm_product.rb
+++ b/spec/models/habtm_product.rb
@@ -1,0 +1,7 @@
+class HabtmProduct < ActiveRecord::Base
+  has_many :habtm_categories_products, dependent: :destroy
+  has_many :habtm_categories, through: :habtm_categories_products, class_name: 'HabtmCategory'
+  
+  scope :visible, -> { where(visible: true) } # to be able to mix with conditional counts
+
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -225,6 +225,21 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "special_poly_images_count", :default => 0, :null => false
   end
 
+  create_table "habtm_products", :force => true  do |t|
+    t.string  "name", :null => false
+    t.boolean  "visible", default: false
+  end
+
+  create_table "habtm_categories", :force => true  do |t|
+    t.string  "name", :null => false
+    t.integer "products_count", default: 0, null: false
+  end
+
+  create_table "habtm_categories_products", :force => true  do |t|
+    t.integer  "habtm_category_id", :null => false
+    t.integer  "habtm_product_id", :null => false
+  end
+
   create_table "conversations", :force => true do |t|
     t.integer "candidate_id"
   end


### PR DESCRIPTION
I've added rspec example for a habtm relation. 

- Given a `product.create("A product", categories: [old_category])`
- When `product.update(categories: [new_category1, new_category2])` is updating,
- The `old_category` relation is deleted, but the counter for `old_category` stays untouched. 

(The `new_categories` are counted properly!)

The other spec tests are mostly sanity checks 