### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+              ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
               rails-version: ["5.2", "6.0", "6.1", "7.0"]
               database: ["postgresql", "sqlite3", "mysql2"]
             exclude:
@@ -65,6 +65,15 @@ workflows:
                 rails-version: "5.2"
                 database: "postgresql"
               - ruby-version: "3.1"
+                rails-version: "5.2"
+                database: "sqlite3"
+              - ruby-version: "3.2"
+                rails-version: "5.2"
+                database: "mysql2"
+              - ruby-version: "3.2"
+                rails-version: "5.2"
+                database: "postgresql"
+              - ruby-version: "3.2"
                 rails-version: "5.2"
                 database: "sqlite3"
               - ruby-version: "3.1"


### PR DESCRIPTION
I'm not sure if Ruby 3.2 will work with Rails 6.0 or 6.1. One or both of those may need to be excluded.