### PR TITLE
Set required_ruby_version to officially supported Ruby versions

### DIFF
--- a/counter_culture.gemspec
+++ b/counter_culture.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/magnusvk/counter_culture'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = '>= 2.6'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
As a user of this gem, when I run `bundle install`, I want it resolved to the latest version that is guaranteed to work with the Ruby version I am currently using.

From looking at CHANGELOG.md, it seems that this Gem currently only officially supports Ruby 2.6 and above. This leads me to believe that it would be better to keep the required_ruby_version in line with that as well.

What do you think?