### PR TITLE
Handle reading primary key option from polymorphic association

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -284,6 +284,8 @@ module CounterCulture
       if reflect.options.key?(:polymorphic)
         raise "can't handle multiple keys with polymorphic associations" unless (relation.is_a?(Symbol) || relation.length == 1)
         raise "must specify source for polymorphic associations..." unless source
+
+        return reflect.options[:primary_key] if reflect.options.key?(:primary_key)
         return relation_klass(relation, source: source, was: was).try(:primary_key)
       end
       reflect.association_primary_key(klass)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2326,6 +2326,30 @@ RSpec.describe "CounterCulture" do
         expect(employee.reload.poly_images_count).to eq(1)
       end
     end
+
+    describe 'using custom indexes as primary keys' do
+      it "increments / decrements counter caches correctly" do
+        expect(employee.poly_images_from_uids_count).to eq(0)
+        expect(product1.poly_images_from_uids_count).to eq(0)
+        img1 = PolyImage.create(imageable_from_uid: employee)
+        expect(employee.reload.poly_images_from_uids_count).to eq(1)
+        expect(product1.reload.poly_images_from_uids_count).to eq(0)
+        img2 = PolyImage.create(imageable_from_uid: product1)
+        expect(employee.reload.poly_images_from_uids_count).to eq(1)
+        expect(product1.reload.poly_images_from_uids_count).to eq(1)
+        img3 = PolyImage.create(imageable_from_uid: product1)
+        expect(employee.reload.poly_images_from_uids_count).to eq(1)
+        expect(product1.reload.poly_images_from_uids_count).to eq(2)
+        img3.destroy
+        expect(employee.reload.poly_images_from_uids_count).to eq(1)
+        expect(product1.reload.poly_images_from_uids_count).to eq(1)
+        img2.imageable_from_uid = employee
+        img2.save!
+        expect(employee.reload.poly_images_from_uids_count).to eq(2)
+        expect(product1.reload.poly_images_from_uids_count).to eq(0)
+      end
+    end
+
     describe "custom column name" do
       it "increments counter cache on create" do
         expect(employee.poly_images_count_dup).to eq(0)

--- a/spec/models/poly_employee.rb
+++ b/spec/models/poly_employee.rb
@@ -1,3 +1,14 @@
 class PolyEmployee < ActiveRecord::Base
   has_many :poly_images, as: :imageable
+  has_many :poly_images_from_uids, as: :imageable_from_uid,
+      class_name: 'PolyImage',
+      foreign_key: :imageable_uid,
+      foreign_type: :imageable_type,
+      primary_key: :uid
+
+  before_create :set_uid
+
+  def set_uid
+    self.uid = SecureRandom.uuid
+  end
 end

--- a/spec/models/poly_image.rb
+++ b/spec/models/poly_image.rb
@@ -1,15 +1,15 @@
 class PolyImage < ActiveRecord::Base
   belongs_to :imageable, polymorphic: true
+  belongs_to :imageable_from_uid, polymorphic: true, foreign_key: :imageable_uid, foreign_type: :imageable_type, primary_key: :uid
   counter_culture :imageable
+  counter_culture :imageable_from_uid, column_name: 'poly_images_from_uids_count'
   counter_culture :imageable, column_name: 'poly_images_count_dup'
   counter_culture :imageable, column_name: ->(i){i.special? ? 'special_poly_images_count' : nil },
     column_names: {
         ["poly_images.url LIKE ?", '%special%'] => 'special_poly_images_count',
     }
 
-
   def special?
     url && url.include?('special')
   end
-
 end

--- a/spec/models/poly_product.rb
+++ b/spec/models/poly_product.rb
@@ -1,4 +1,14 @@
 class PolyProduct < ActiveRecord::Base
   self.primary_key = :pp_pk_id
   has_many :poly_images, as: :imageable
+  has_many :poly_images_from_uids, as: :imageable_from_uid,
+      class_name: 'PolyImage',
+      foreign_key: :imageable_uid,
+      primary_key: :uid
+
+  before_create :set_uid
+
+  def set_uid
+    self.uid = SecureRandom.uuid
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -208,20 +208,25 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   create_table "poly_images", :force => true do |t|
     t.integer "imageable_id", :null => true
     t.string "imageable_type", :null => true
+    t.string "imageable_uid", :null => true
     t.string "url"
   end
 
   create_table "poly_employees", :force => true do |t|
     t.string "name"
+    t.string "uid"
     t.integer  "poly_images_count", :default => 0, :null => false
     t.integer  "poly_images_count_dup", :default => 0, :null => false
+    t.integer  "poly_images_from_uids_count", :default => 0, :null => false
     t.integer  "special_poly_images_count", :default => 0, :null => false
   end
 
   create_table "poly_products", :primary_key => 'pp_pk_id', :force => true do |t|
     t.string "brand_name"
+    t.string "uid"
     t.integer  "poly_images_count", :default => 0, :null => false
     t.integer  "poly_images_count_dup", :default => 0, :null => false
+    t.integer  "poly_images_from_uids_count", :default => 0, :null => false
     t.integer  "special_poly_images_count", :default => 0, :null => false
   end
 


### PR DESCRIPTION
## Content

Allow reading the `primary_key` option on polymorphic associations when it's present instead of returning the association's `primary_key`.

Basically the issue is that I have an association defined such as:

```
  belongs_to :target, polymorphic: true, foreign_key: :target_uid, primary_key: :uid

  has_many :something_plurals, 
      as: :target,
      class_name: 'SomeClass',
      inverse_of: :target,
      foreign_key: :target_uid,
      primary_key: :uid
```

and yet `counter_culture` gem was trying to hit `Target#id` because `uid` is not the primary column of the table for now.

So my fix is to bypass the reflection on primary key if it's explicitly part of the polymorphic definition.