### PR TITLE
Add options as an argument for column_names proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,23 @@ dynamic, you can pass `skip_unsupported`:
 Product.counter_culture_fix_counts skip_unsupported: true
 ```
 
+You can also use context within the block that was provided with the `column_names` method:
+
+```ruby
+class Product < ActiveRecord::Base
+  belongs_to :category
+  scope :awesomes, -> (ids) { where(ids: ids, product_type: 'awesome') }
+
+  counter_culture :category,
+      column_name: 'awesome_count'
+      column_names: -> (context) {
+        { Product.awesomes(context[:ids]) => :awesome_count }
+      }
+end
+
+Product.counter_culture_fix_counts(context: { ids: [1, 2] })
+```
+
 #### Handling over-written, dynamic foreign keys
 
 Manually populating counter caches with dynamically over-written foreign keys (```:foreign_key_values``` option) is not supported. You will have to write code to handle this case yourself.

--- a/lib/counter_culture/extensions.rb
+++ b/lib/counter_culture/extensions.rb
@@ -84,7 +84,7 @@ module CounterCulture
           next if options[:exclude] && options[:exclude].include?(counter.relation)
           next if options[:only] && !options[:only].include?(counter.relation)
 
-          reconciler_options = %i(batch_size column_name db_connection_builder finish skip_unsupported start touch verbose where polymorphic_classes)
+          reconciler_options = %i(context batch_size column_name db_connection_builder finish skip_unsupported start touch verbose where polymorphic_classes)
 
           reconciler = CounterCulture::Reconciler.new(counter, options.slice(*reconciler_options))
           reconciler.reconcile!

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -77,7 +77,11 @@ module CounterCulture
         counter_column_names =
           case column_names
           when Proc
-            column_names.call
+            if column_names.lambda? && column_names.arity == 0
+              column_names.call
+            else
+              column_names.call(options.fetch(:context, {}))
+            end
           when Hash
             column_names
           else

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2778,6 +2778,24 @@ RSpec.describe "CounterCulture" do
     end
 
     context "when column_names is a Proc" do
+      context "when column_names uses context" do
+        let(:column_names) do
+          proc { |context|
+            @called = context
+            { City.big => :big_cities_count }
+          }
+        end
+
+        it "injects options inside block" do
+          @called = false
+          City.counter_culture :prefecture, column_name: :big_cities_count, column_names: column_names
+
+          City.counter_culture_fix_counts(context: true)
+
+          expect(@called).to eq(true)
+        end
+      end
+
       context "when the return value is not a hash" do
         it "does not call the proc right away" do
           called = false


### PR DESCRIPTION
Hello. We are using column_names method for recalculating total counters. And found a problem with the large SQL scope for update:
```ruby
class Attendance < ApplicationRecord
  ...
  counter_culture :event,
                  column_name: :missing_attendees_count,
                  column_names: -> { {Attendance.can_not_participate => :missing_attendees_count} }
```

```ruby
ids_for_update = {id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
Attendance.counter_culture_fix_counts(where: { Event.table_name => ids_for_update })
```

The current logic builds an SQL query like this:
```sql
SELECT "events".id, "events".id,
  COUNT("attendances".id)*1 AS count,
  MAX("events".missing_attendees_count) AS missing_attendees_count
FROM "events"
LEFT JOIN "attendances" AS attendances ON "events".id = attendances.event_id AND attendances.id IN (
  /*<<LARGE SELECT SQL SCOPE>>*/
)
WHERE "events"."id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
GROUP BY "events"."id"
ORDER BY "events"."id" ASC
LIMIT 1000
```
To get the data, the database should first load all the nested SQL.
I suggest pushing options to column_names for further filtering within the scope if needed:
```ruby
  counter_culture :event,
                  column_name: :missing_attendees_count,
                  column_names: -> (options) { {Attendance.can_not_participate(options) => :missing_attendees_count} }
```

There is only one problem with backward compatibility, if someone uses lambda for column_names instead of proc.