### PR TITLE
Remove condition when Rails.version < 4.0.0 in user.rb

### DIFF
--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -20,17 +20,9 @@ class User < ActiveRecord::Base
   default_scope do
     if _default_scope_enabled
       query = joins("LEFT OUTER JOIN companies ON users.company_id = companies.id")
-      if Rails.version < "5.0.0"
-        query = query.uniq
-      else
-        query = query.distinct
-      end
+      Rails.version < "5.0.0" ? query.uniq : query.distinct
     else
-      if Rails.version < "4.0.0"
-        scoped
-      else
-        all
-      end
+      all
     end
   end
 


### PR DESCRIPTION
Removed unnecessary conditional branching from user.rb.
Rails.version < "4.0.0" was dropped in https://github.com/magnusvk/counter_culture/pull/252 