### PR TITLE
Fix touching for counted models without updated_at

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -81,8 +81,8 @@ module CounterCulture
         end
         # and here we update the timestamp, if so desired
         if touch
-          current_time = obj.send(:current_time_from_proper_timezone)
-          timestamp_columns = obj.send(:timestamp_attributes_for_update_in_model)
+          current_time = klass.send(:current_time_from_proper_timezone)
+          timestamp_columns = klass.send(:timestamp_attributes_for_update_in_model)
           if touch != true
             # starting in Rails 6 this is frozen
             timestamp_columns = timestamp_columns.dup

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -16,6 +16,7 @@ require 'models/conditional_main'
 require 'models/conditional_dependent'
 require 'models/post'
 require 'models/post_comment'
+require 'models/post_like'
 require 'models/categ'
 require 'models/subcateg'
 require 'models/another_post'
@@ -2925,5 +2926,12 @@ RSpec.describe "CounterCulture" do
     po.purchase_order_items.destroy_all
     po.reload
     expect(po.total_amount).to eq(0.0)
+  end
+
+  it "should touch the record when the counter cache is updated" do
+    post = Post.create!
+    Timecop.travel(2.second.from_now) do
+      expect { PostLike.create!(post: post) }.to change { post.reload.updated_at }
+    end
   end
 end

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -4,6 +4,7 @@ class Post < ActiveRecord::Base
   belongs_to :subcateg, :foreign_key => :fk_subcat_id
 
   has_many :post_comments
+  has_many :post_likes
   counter_culture :subcateg, :column_name => :posts_count
   counter_culture :subcateg, :column_name => :posts_after_commit_count,
     :execute_after_commit => true,

--- a/spec/models/post_like.rb
+++ b/spec/models/post_like.rb
@@ -1,0 +1,4 @@
+class PostLike < ActiveRecord::Base
+  belongs_to :post, :foreign_key => 'post_id'
+  counter_culture :post, :column_name => :likes_count, touch: true
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -156,6 +156,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.string   "title"
     t.integer  "fk_subcat_id", :default => nil
     t.integer  "comments_count", :null => false, :default => 0
+    t.integer  "likes_count", :null => false, :default => 0
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end
@@ -164,6 +165,11 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.string   "comment"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+  end
+
+  create_table "post_likes", :force => true do |t|
+    t.integer  "post_id", :null => false
+    t.datetime "created_at", :null => false
   end
 
   create_table "another_posts", :force => true do |t|


### PR DESCRIPTION
We recently encountered a bug that prevents object from being touched correctly. 

When counter_culture tries to find touch column, it uses counted model for `timestamp_attributes_for_update_in_model`. However, counted model might have no updated_at column, and we should check model with counters to find correct timestamp attributes.

This issue is illustrated in my first commit, and fixed in second commit.