### PR TITLE
Combine multiple updates into a single SQL per target row (N+1)

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -28,15 +28,15 @@ module CounterCulture
     # aggregate the updates for each target record and execute SQL queries
     Thread.current[:aggregated_updates].each do |klass, attrs|
       attrs.each do |rec_id, updates|
-        updated_columns = updates.map do |operation, value|
+        update_snippets = updates.map do |operation, value|
           value = value.call if value.is_a?(Proc)
           %Q{#{operation} #{value.is_a?(String) ? "'#{value}'" : value}} unless value == 0
         end.compact
 
-        if updated_columns.any?
+        if update_snippets.any?
           klass
             .where(Thread.current[:primary_key_map][klass] => rec_id)
-            .update_all(updated_columns.join(', '))
+            .update_all(update_snippets.join(', '))
         end
       end
     end

--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -23,7 +23,7 @@ module CounterCulture
     Thread.current[:aggregated_updates] = {}
     Thread.current[:primary_key_map] = {}
 
-    yield
+    result = yield
 
     # aggregate the updates for each target record and execute SQL queries
     Thread.current[:aggregated_updates].each do |klass, attrs|
@@ -40,6 +40,8 @@ module CounterCulture
         end
       end
     end
+
+    result
   ensure
     Thread.current[:aggregate_counter_updates] = false
     Thread.current[:aggregated_updates] = nil

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -360,33 +360,23 @@ module CounterCulture
     end
 
     def assemble_money_counter_update(klass, id_to_change, quoted_column, operator, delta_magnitude)
-      update = "#{quoted_column} = COALESCE(CAST(#{quoted_column} as NUMERIC), 0)"
-
-      if Thread.current[:aggregate_counter_updates]
-        remember_counter_update(
-          klass,
-          id_to_change,
-          "#{update} +",
-          operator == '+' ? delta_magnitude : -delta_magnitude
-        )
-      else
-        "#{update} #{operator} #{delta_magnitude}"
-      end
+      counter_update_snippet(
+        "#{quoted_column} = COALESCE(CAST(#{quoted_column} as NUMERIC), 0)",
+        klass,
+        id_to_change,
+        operator,
+        delta_magnitude
+      )
     end
 
     def assemble_counter_update(klass, id_to_change, quoted_column, operator, delta_magnitude)
-      update = "#{quoted_column} = COALESCE(#{quoted_column}, 0)"
-
-      if Thread.current[:aggregate_counter_updates]
-        remember_counter_update(
-          klass,
-          id_to_change,
-          "#{update} +",
-          operator == '+' ? delta_magnitude : -delta_magnitude
-        )
-      else
-        "#{update} #{operator} #{delta_magnitude}"
-      end
+      counter_update_snippet(
+        "#{quoted_column} = COALESCE(#{quoted_column}, 0)",
+        klass,
+        id_to_change,
+        operator,
+        delta_magnitude
+      )
     end
 
     def assemble_timestamp_update(klass, id_to_change, timestamp_column, value)
@@ -396,6 +386,19 @@ module CounterCulture
         remember_timestamp_update(klass, id_to_change, update, value)
       else
         "#{update} '#{value.call}'"
+      end
+    end
+
+    def counter_update_snippet(update, klass, id_to_change, operator, delta_magnitude)
+      if Thread.current[:aggregate_counter_updates]
+        remember_counter_update(
+          klass,
+          id_to_change,
+          "#{update} +",
+          operator == '+' ? delta_magnitude : -delta_magnitude
+        )
+      else
+        "#{update} #{operator} #{delta_magnitude}"
       end
     end
 

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -74,14 +74,14 @@ module CounterCulture
         # we don't use Rails' update_counters because we support changing the timestamp
         updates = []
 
-        # this updates the actual counter
+        # this will update the actual counter
         updates << if column_type == :money
           assemble_money_counter_update(klass, id_to_change, quoted_column, operator, delta_magnitude)
         else
           assemble_counter_update(klass, id_to_change, quoted_column, operator, delta_magnitude)
         end
 
-        # and here we update the timestamp, if so desired
+        # and this will update the timestamp, if so desired
         if touch
           current_time = klass.send(:current_time_from_proper_timezone)
           timestamp_columns = klass.send(:timestamp_attributes_for_update_in_model)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2969,6 +2969,142 @@ RSpec.describe "CounterCulture" do
   end
 
   context "with aggregate_counter_updates" do
+    it "aggregates SQL queries" do
+      user = User.create
+      user2 = User.create
+      product1 = Product.create
+      product2 = Product.create
+
+      expect(user.reviews_count).to eq(0)
+      expect(user2.reviews_count).to eq(0)
+      expect(product1.reviews_count).to eq(0)
+      expect(product2.reviews_count).to eq(0)
+      expect(user.review_approvals_count).to eq(0)
+      expect(user2.review_approvals_count).to eq(0)
+
+      Timecop.freeze do
+        user_update = %Q{
+          UPDATE `users` SET
+            `users`.`reviews_count` = COALESCE(`users`.`reviews_count`, 0) + 2,
+            `users`.`using_count` = COALESCE(`users`.`using_count`, 0) + 2,
+            `users`.`review_approvals_count` = COALESCE(`users`.`review_approvals_count`, 0) + 10,
+            `users`.`dynamic_delta_count` = COALESCE(`users`.`dynamic_delta_count`, 0) + 2,
+            `users`.`custom_delta_count` = COALESCE(`users`.`custom_delta_count`, 0) + 6
+          WHERE `users`.`id` = #{user.id}
+        }.squish
+
+        user2_update = %Q{
+          UPDATE `users` SET
+            `users`.`reviews_count` = COALESCE(`users`.`reviews_count`, 0) + 1,
+            `users`.`using_count` = COALESCE(`users`.`using_count`, 0) + 1,
+            `users`.`review_approvals_count` = COALESCE(`users`.`review_approvals_count`, 0) + 5,
+            `users`.`dynamic_delta_count` = COALESCE(`users`.`dynamic_delta_count`, 0) + 1,
+            `users`.`custom_delta_count` = COALESCE(`users`.`custom_delta_count`, 0) + 3
+          WHERE `users`.`id` = #{user2.id}
+        }.squish
+
+        product1_update = %Q{
+          UPDATE `products` SET
+            `products`.`reviews_count` = COALESCE(`products`.`reviews_count`, 0) + 2,
+            updated_at = '#{Product.send(:current_time_from_proper_timezone).to_formatted_s(:db)}',
+            `products`.`rexiews_count` = COALESCE(`products`.`rexiews_count`, 0) + 2,
+            rexiews_updated_at = '#{Product.send(:current_time_from_proper_timezone).to_formatted_s(:db)}'
+          WHERE `products`.`id` = #{product1.id}
+        }.squish
+
+        product2_update = %Q{
+          UPDATE `products` SET
+            `products`.`reviews_count` = COALESCE(`products`.`reviews_count`, 0) + 1,
+            updated_at = '#{Product.send(:current_time_from_proper_timezone).to_formatted_s(:db)}',
+            `products`.`rexiews_count` = COALESCE(`products`.`rexiews_count`, 0) + 1,
+            rexiews_updated_at = '#{Product.send(:current_time_from_proper_timezone).to_formatted_s(:db)}'
+          WHERE `products`.`id` = #{product2.id}
+        }.squish
+
+        expect_queries(1, filter: /UPDATE .* WHERE `users`.`id` = #{user.id}/) do # only one query for user in total
+          expect_queries(1, filter: user_update) do
+            expect_queries(1, filter: /UPDATE .* WHERE `users`.`id` = #{user2.id}/) do # only one query for user2 in total
+              expect_queries(1, filter: user2_update) do
+                expect_queries(2, filter: /UPDATE .* WHERE `products`.`id` = #{product1.id}/) do # one query for product1 + papertrail timestamp update
+                  expect_queries(1, filter: product1_update) do
+                    expect_queries(2, filter: /UPDATE .* WHERE `products`.`id` = #{product2.id}/) do # one query for product2 + papertrail timestamp update
+                      expect_queries(1, filter: product2_update) do
+                        CounterCulture.aggregate_counter_updates do
+                          user.reviews.create :user_id => user.id, :product_id => product1.id, :approvals => 5
+                          user2.reviews.create :user_id => user2.id, :product_id => product1.id, :approvals => 5
+                          user.reviews.create :user_id => user.id, :product_id => product2.id, :approvals => 5
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      user.reload
+      user2.reload
+      product1.reload
+      product2.reload
+
+      expect(user.reviews_count).to eq(2)
+      expect(user.using_count).to eq(2)
+      expect(user.review_approvals_count).to eq(10)
+      expect(user.dynamic_delta_count).to eq(2)
+      expect(user.custom_delta_count).to eq(6)
+      expect(user2.reviews_count).to eq(1)
+      expect(user2.using_count).to eq(1)
+      expect(user2.review_approvals_count).to eq(5)
+      expect(user2.dynamic_delta_count).to eq(1)
+      expect(user2.custom_delta_count).to eq(3)
+      expect(product1.reviews_count).to eq(2)
+      expect(product1.rexiews_count).to eq(2)
+      expect(product2.reviews_count).to eq(1)
+      expect(product2.rexiews_count).to eq(1)
+    end
+
+    it "skips aggregated counter updates with zero increment" do
+      user = User.create
+      product1 = Product.create
+
+      expect(user.reviews_count).to eq(0)
+      expect(product1.reviews_count).to eq(0)
+      expect(user.review_approvals_count).to eq(0)
+
+      Timecop.freeze do
+        product1_update = %Q{
+          UPDATE `products` SET
+            updated_at = '#{Product.send(:current_time_from_proper_timezone).to_formatted_s(:db)}',
+            rexiews_updated_at = '#{Product.send(:current_time_from_proper_timezone).to_formatted_s(:db)}'
+          WHERE `products`.`id` = #{product1.id}
+        }.squish
+
+        expect_queries(0, filter: /UPDATE .* WHERE `users`.`id` = #{user.id}/) do # all columns are incremented by 0 so no query
+          expect_queries(1, filter: product1_update) do # only the timestamp column is updated because counters are incremented by 0
+            expect_queries(2, filter: /UPDATE .* WHERE `products`.`id` = #{product1.id}/) do # one query for product1 + papertrail timestamp update
+              CounterCulture.aggregate_counter_updates do
+                review = user.reviews.create :user_id => user.id, :product_id => product1.id, :approvals => 5
+                review.destroy!
+              end
+            end
+          end
+        end
+      end
+
+      user.reload
+      product1.reload
+
+      expect(user.reviews_count).to eq(0)
+      expect(user.using_count).to eq(0)
+      expect(user.review_approvals_count).to eq(0)
+      expect(user.dynamic_delta_count).to eq(0)
+      expect(user.custom_delta_count).to eq(0)
+      expect(product1.reviews_count).to eq(0)
+      expect(product1.rexiews_count).to eq(0)
+    end
+
     it "updates counter caches" do
       user = User.create
       product1 = Product.create

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -2983,7 +2983,7 @@ RSpec.describe "CounterCulture" do
       expect(user2.review_approvals_count).to eq(0)
 
       Timecop.freeze do
-        expect_queries(2, filter: /UPDATE `users`/) do # user updates
+        expect_queries(2, filter: /UPDATE users/) do # user updates
           expect_queries(2, filter: /rexiews_updated_at/) do # product updates
             CounterCulture.aggregate_counter_updates do
               user.reviews.create :user_id => user.id, :product_id => product1.id, :approvals => 5
@@ -3028,7 +3028,7 @@ RSpec.describe "CounterCulture" do
       expect(user.review_approvals_count).to eq(0)
 
       Timecop.freeze do
-        expect_queries(0, filter: /UPDATE `users`/) do # all columns are incremented by 0 so no query
+        expect_queries(0, filter: /UPDATE users/) do # all columns are incremented by 0 so no query
           expect_queries(1, filter: /rexiews_updated_at/) do
             expect_queries(0, filter: /rexiews_count/) do # only the timestamp column is updated because counters are incremented by 0
               CounterCulture.aggregate_counter_updates do

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -3021,13 +3021,15 @@ RSpec.describe "CounterCulture" do
           WHERE `products`.`id` = #{product2.id}
         }.squish
 
+        product_query_count = PapertrailSupport.supported_here? ? 2 : 1
+
         expect_queries(1, filter: /UPDATE .* WHERE `users`.`id` = #{user.id}/) do # only one query for user in total
           expect_queries(1, filter: user_update) do
             expect_queries(1, filter: /UPDATE .* WHERE `users`.`id` = #{user2.id}/) do # only one query for user2 in total
               expect_queries(1, filter: user2_update) do
-                expect_queries(2, filter: /UPDATE .* WHERE `products`.`id` = #{product1.id}/) do # one query for product1 + papertrail timestamp update
+                expect_queries(product_query_count, filter: /UPDATE .* WHERE `products`.`id` = #{product1.id}/) do # one query for product1 + papertrail timestamp update
                   expect_queries(1, filter: product1_update) do
-                    expect_queries(2, filter: /UPDATE .* WHERE `products`.`id` = #{product2.id}/) do # one query for product2 + papertrail timestamp update
+                    expect_queries(product_query_count, filter: /UPDATE .* WHERE `products`.`id` = #{product2.id}/) do # one query for product2 + papertrail timestamp update
                       expect_queries(1, filter: product2_update) do
                         CounterCulture.aggregate_counter_updates do
                           user.reviews.create :user_id => user.id, :product_id => product1.id, :approvals => 5
@@ -3081,9 +3083,11 @@ RSpec.describe "CounterCulture" do
           WHERE `products`.`id` = #{product1.id}
         }.squish
 
+        product_query_count = PapertrailSupport.supported_here? ? 2 : 1
+
         expect_queries(0, filter: /UPDATE .* WHERE `users`.`id` = #{user.id}/) do # all columns are incremented by 0 so no query
           expect_queries(1, filter: product1_update) do # only the timestamp column is updated because counters are incremented by 0
-            expect_queries(2, filter: /UPDATE .* WHERE `products`.`id` = #{product1.id}/) do # one query for product1 + papertrail timestamp update
+            expect_queries(product_query_count, filter: /UPDATE .* WHERE `products`.`id` = #{product1.id}/) do # one query for product1 + papertrail timestamp update
               CounterCulture.aggregate_counter_updates do
                 review = user.reviews.create :user_id => user.id, :product_id => product1.id, :approvals => 5
                 review.destroy!

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -3012,10 +3012,10 @@ RSpec.describe "CounterCulture" do
         expect(product1.rexiews_count).to eq(2)
         expect(product2.reviews_count).to eq(1)
         expect(product2.rexiews_count).to eq(1)
-        expect(product1.updated_at).to eq(Time.now.utc)
-        expect(product1.rexiews_updated_at).to eq(Time.now.utc)
-        expect(product2.updated_at).to eq(Time.now.utc)
-        expect(product2.rexiews_updated_at).to eq(Time.now.utc)
+        expect(product1.updated_at.to_i).to eq(Time.now.utc.to_i)
+        expect(product1.rexiews_updated_at.to_i).to eq(Time.now.utc.to_i)
+        expect(product2.updated_at.to_i).to eq(Time.now.utc.to_i)
+        expect(product2.rexiews_updated_at.to_i).to eq(Time.now.utc.to_i)
       end
     end
 
@@ -3049,8 +3049,8 @@ RSpec.describe "CounterCulture" do
         expect(user.custom_delta_count).to eq(0)
         expect(product1.reviews_count).to eq(0)
         expect(product1.rexiews_count).to eq(0)
-        expect(product1.updated_at).to eq(Time.now.utc)
-        expect(product1.rexiews_updated_at).to eq(Time.now.utc)
+        expect(product1.updated_at.to_i).to eq(Time.now.utc.to_i)
+        expect(product1.rexiews_updated_at.to_i).to eq(Time.now.utc.to_i)
       end
     end
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -3174,6 +3174,7 @@ RSpec.describe "CounterCulture" do
         skip("money type only supported in PostgreSQL")
       end
 
+      item = nil
       po = PurchaseOrder.create
 
       expect(po.total_amount).to eq(0.0)

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe "CounterCulture" do
     expect(user2.reload.review_approvals_count).to eq(69)
   end
 
-  it "works with multiple saves in one transcation" do
+  it "works with multiple saves in one transaction" do
     user = User.create
     product = Product.create
 
@@ -2945,6 +2945,268 @@ RSpec.describe "CounterCulture" do
     post = Post.create!
     Timecop.travel(2.second.from_now) do
       expect { PostLike.create!(post: post) }.to change { post.reload.updated_at }
+    end
+  end
+
+  context "with aggregate_counter_updates" do
+    it "updates counter caches" do
+      user = User.create
+      product1 = Product.create
+      product2 = Product.create
+      product3 = Product.create
+
+      expect(user.reviews_count).to eq(0)
+      expect(product1.reviews_count).to eq(0)
+      expect(product2.reviews_count).to eq(0)
+      expect(product3.reviews_count).to eq(0)
+      expect(user.review_approvals_count).to eq(0)
+
+      review_to_delete = CounterCulture.aggregate_counter_updates do
+        user.reviews.create :user_id => user.id, :product_id => product1.id, :approvals => 5
+      end
+
+      user.reload
+      product1.reload
+
+      expect(user.reviews_count).to eq(1)
+      expect(user.using_count).to eq(1)
+      expect(user.review_approvals_count).to eq(5)
+      expect(user.dynamic_delta_count).to eq(1)
+      expect(user.custom_delta_count).to eq(3)
+      expect(product1.reviews_count).to eq(1)
+      expect(product1.rexiews_count).to eq(1)
+
+      CounterCulture.aggregate_counter_updates do
+        user.reviews.create :user_id => user.id, :product_id => product2.id, :approvals => 10
+        user.reviews.create :user_id => user.id, :product_id => product3.id, :approvals => 10
+        review_to_delete.destroy!
+        review_to_delete.destroy # this does not decrement counter cache a second time
+      end
+
+      user.reload
+      product1.reload
+      product2.reload
+      product3.reload
+
+      expect(user.reviews_count).to eq(2)
+      expect(user.using_count).to eq(2)
+      expect(user.review_approvals_count).to eq(20)
+      expect(user.dynamic_delta_count).to eq(2)
+      expect(user.custom_delta_count).to eq(6)
+      expect(product1.reviews_count).to eq(0)
+      expect(product1.rexiews_count).to eq(0)
+      expect(product2.reviews_count).to eq(1)
+      expect(product2.rexiews_count).to eq(1)
+      expect(product3.reviews_count).to eq(1)
+      expect(product3.rexiews_count).to eq(1)
+    end
+
+    it "skips incrementing counter cache" do
+      user = User.create
+      category = Category.create
+
+      expect(user.reviews_count).to eq(0)
+      expect(user.review_approvals_count).to eq(0)
+      expect(category.products_count).to eq(0)
+
+      CounterCulture.aggregate_counter_updates do
+        Product.skip_counter_culture_updates do
+          Review.skip_counter_culture_updates do
+            product = category.products.create
+            user.reviews.create :user_id => user.id, :product_id => product.id, :approvals => 13
+          end
+        end
+      end
+
+      user.reload
+      category.reload
+
+      expect(user.reviews_count).to eq(0)
+      expect(user.review_approvals_count).to eq(0)
+      expect(category.products_count).to eq(0)
+    end
+
+    it "increments second-level counter cache" do
+      company = Company.create
+      user = User.create :manages_company_id => company.id
+      product = Product.create
+
+      expect(company.reviews_count).to eq(0)
+      expect(user.reviews_count).to eq(0)
+      expect(product.reviews_count).to eq(0)
+      expect(company.review_approvals_count).to eq(0)
+
+      CounterCulture.aggregate_counter_updates do
+        Review.create :user_id => user.id, :product_id => product.id, :approvals => 314
+      end
+
+      company.reload
+      user.reload
+      product.reload
+
+      expect(company.reviews_count).to eq(1)
+      expect(company.review_approvals_count).to eq(314)
+      expect(user.reviews_count).to eq(1)
+      expect(product.reviews_count).to eq(1)
+    end
+
+    it "updates the timestamp if touch: true is set" do
+      Timecop.freeze do
+        user1 = nil
+        user2 = nil
+        product = nil
+        review1 = nil
+        review2 = nil
+
+        CounterCulture.aggregate_counter_updates do
+          Timecop.travel(10.seconds.ago) do
+            user1 = User.create
+            user2 = User.create
+            product = Product.create
+
+            review1 = Review.create :user_id => user1.id, :product_id => product.id
+          end
+
+          review2 = Review.create :user_id => user2.id, :product_id => product.id
+        end
+
+        user1.reload; user2.reload; product.reload
+
+        expect(user1.created_at.to_i).to eq(user1.updated_at.to_i)
+        expect(user2.created_at.to_i).to eq(user2.updated_at.to_i)
+        expect(product.created_at.to_i).to be < product.updated_at.to_i
+        expect(product.updated_at.to_i).to eq(review2.created_at.to_i)
+        expect(user1.reviews_count).to eq(1)
+        expect(user2.reviews_count).to eq(1)
+        expect(product.reviews_count).to eq(2)
+      end
+    end
+
+    it "updates counter correctly when creating using nested attributes" do
+      user = CounterCulture.aggregate_counter_updates do
+        User.create(:reviews_attributes => [{:some_text => 'abc'}, {:some_text => 'xyz'}])
+      end
+
+      user.reload
+      expect(user.reviews_count).to eq(2)
+    end
+
+
+    it "increments self-referential counter cache" do
+      company = Company.create!
+
+      CounterCulture.aggregate_counter_updates do
+        company.children << Company.create!
+      end
+
+      company.reload
+      expect(company.children_count).to eq(1)
+    end
+
+    it "correctly sums up the values for dynamic column names with totaling instead of counting" do
+      person = Person.create!
+
+      earning_transaction = CounterCulture.aggregate_counter_updates do
+        Transaction.create(monetary_value: 10, person: person)
+      end
+
+      person.reload
+      expect(person.money_earned_total).to eq(10)
+
+      spending_transaction = CounterCulture.aggregate_counter_updates do
+        Transaction.create(monetary_value: -20, person: person)
+      end
+
+      person.reload
+      expect(person.money_spent_total).to eq(-20)
+    end
+
+    it "increments / decrements counter caches correctly for polymorphic association" do
+      require 'models/poly_image'
+      require 'models/poly_employee'
+      require 'models/poly_product'
+
+      employee = PolyEmployee.create(id: 3000)
+      product1 = PolyProduct.create()
+
+      expect(employee.poly_images_count).to eq(0)
+      expect(product1.poly_images_count).to eq(0)
+
+      img1 = CounterCulture.aggregate_counter_updates do
+        PolyImage.create(imageable: employee)
+      end
+
+      expect(employee.reload.poly_images_count).to eq(1)
+      expect(product1.reload.poly_images_count).to eq(0)
+
+      img2 = CounterCulture.aggregate_counter_updates do
+        PolyImage.create(imageable: product1)
+      end
+
+      expect(employee.reload.poly_images_count).to eq(1)
+      expect(product1.reload.poly_images_count).to eq(1)
+
+      img3 = CounterCulture.aggregate_counter_updates do
+        PolyImage.create(imageable: product1)
+      end
+
+      expect(employee.reload.poly_images_count).to eq(1)
+      expect(product1.reload.poly_images_count).to eq(2)
+
+      CounterCulture.aggregate_counter_updates do
+        img3.destroy
+      end
+
+      expect(employee.reload.poly_images_count).to eq(1)
+      expect(product1.reload.poly_images_count).to eq(1)
+
+      CounterCulture.aggregate_counter_updates do
+        img2.imageable = employee
+        img2.save!
+      end
+
+      expect(employee.reload.poly_images_count).to eq(2)
+      expect(product1.reload.poly_images_count).to eq(0)
+    end
+
+    it "works with pg money type" do
+      if ENV['DB'] != 'postgresql'
+        skip("money type only supported in PostgreSQL")
+      end
+
+      po = PurchaseOrder.create
+
+      expect(po.total_amount).to eq(0.0)
+
+      CounterCulture.aggregate_counter_updates do
+        item = po.purchase_order_items.build(amount: 100.00)
+        item.save
+      end
+
+      po.reload
+      expect(po.total_amount).to eq(100.0)
+
+      CounterCulture.aggregate_counter_updates do
+        item = po.purchase_order_items.build(amount: 100.00)
+        item.save
+      end
+
+      po.reload
+      expect(po.total_amount).to eq(200.0)
+
+      CounterCulture.aggregate_counter_updates do
+        item.destroy
+      end
+
+      po.reload
+      expect(po.total_amount).to eq(100.0)
+
+      CounterCulture.aggregate_counter_updates do
+        po.purchase_order_items.destroy_all
+      end
+
+      po.reload
+      expect(po.total_amount).to eq(0.0)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,8 @@ def expect_queries(num = 1, filter: "", &block)
     next if payload[:sql].match?(/^SELECT a\.attname/)
     next unless payload[:sql].match?(/^SELECT|UPDATE|INSERT/)
 
+    payload[:sql].gsub!(%Q{\"}, "`") # to remove differences between DB adaptors
+
     matches_filter = filter.is_a?(Regexp) ? payload[:sql].match?(filter) : payload[:sql] == filter
     next unless matches_filter
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,12 +110,12 @@ def expect_queries(num = 1, filter: "", &block)
     next if payload[:sql].match?(/^SELECT a\.attname/)
     next unless payload[:sql].match?(/^SELECT|UPDATE|INSERT/)
 
-    payload[:sql].gsub!(%Q{\"}, "`") # to remove differences between DB adaptors
+    sql = payload[:sql].gsub(%Q{\"}, "`") # to remove differences between DB adaptors
 
-    matches_filter = filter.is_a?(Regexp) ? payload[:sql].match?(filter) : payload[:sql] == filter
+    matches_filter = filter.is_a?(Regexp) ? sql.match?(filter) : sql == filter
     next unless matches_filter
 
-    queries.push(payload[:sql])
+    queries.push(sql)
   end
 
   ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,9 +110,9 @@ def expect_queries(num = 1, filter: "", &block)
     next if payload[:sql].match?(/^SELECT a\.attname/)
     next unless payload[:sql].match?(/^SELECT|UPDATE|INSERT/)
 
-    sql = payload[:sql].gsub(%Q{\"}, "`") # to remove differences between DB adaptors
+    sql = payload[:sql].gsub(%Q{\"}, '').gsub('`', '') # to remove differences between DB adaptors
 
-    matches_filter = filter.is_a?(Regexp) ? sql.match?(filter) : sql == filter
+    matches_filter = sql.match?(filter.gsub(%Q{\"}, '').gsub('`', ''))
     next unless matches_filter
 
     queries.push(sql)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,7 +112,7 @@ def expect_queries(num = 1, filter: "", &block)
 
     sql = payload[:sql].gsub(%Q{\"}, '').gsub('`', '') # to remove differences between DB adaptors
 
-    matches_filter = sql.match?(filter.gsub(%Q{\"}, '').gsub('`', ''))
+    matches_filter = sql.match?(filter)
     next unless matches_filter
 
     queries.push(sql)


### PR DESCRIPTION
### Description

Title says it all 😄 

This had been brewing in my mind for quite a while and I finally got to implement it. I wanted it to be completely opt-in and not affect the normal flow. Implementation is not ideal but I felt like I didn't have too many options based on the current level of coupling and abstractions. I think it's abstracted enough to make it easy to maintain and hard to break even in the current state. Am open for suggestions though!

**Fixes:**
https://github.com/magnusvk/counter_culture/issues/307
https://github.com/magnusvk/counter_culture/issues/354

### TL;DR

<details><summary>Sums multiple counter updates for single column of a single target record</summary>

```sql
-- Before
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1

-- After
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 2 WHERE `authors`.`id` = 1
```

```sql
-- Before
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1

-- After
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + -2 WHERE `authors`.`id` = 1
```

```sql
-- Before
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1

-- After
No query
```

</details>

<details><summary>Combines multiple updates for multiple columns of a single target record</summary>

```sql
-- Before
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1, updated_at = '2024-06-06 01:00:00' WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1, updated_at = '2024-06-06 02:00:00' WHERE `authors`.`id` = 1

-- After
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 2, updated_at = '2024-06-06 02:00:00' WHERE `authors`.`id` = 1
```

```sql
-- Before
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`works_count` = COALESCE(`authors`.`works_count`, 0) + 1 WHERE `authors`.`id` = 1

-- After
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1, `authors`.`works_count` = COALESCE(`authors`.`works_count`, 0) + 1 WHERE `authors`.`id` = 1
```

</details>

</details>

<details><summary>Combines multiple updates of multiple target records</summary>

```sql
-- Before
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) - 1 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 2
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 2
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 1 WHERE `authors`.`id` = 2

-- After
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + -3 WHERE `authors`.`id` = 1
UPDATE `authors` SET `authors`.`books_count` = COALESCE(`authors`.`books_count`, 0) + 3 WHERE `authors`.`id` = 2
```

</details>

<details><summary>Executes aggregated updates before commit</summary>

```ruby
ActiveRecord::Base.transaction do
  CounterCulture.aggregate_counter_updates do
    # list of updates
  end
end
```

</details>

<details><summary>Executes aggregated updates after commit</summary>

```ruby
CounterCulture.aggregate_counter_updates do
  ActiveRecord::Base.transaction do
    # list of updates
  end
end
```

</details>

### Implementation

I needed a higher domain of visibility for this mechanism to work, that's why I added the `CounterCulture.aggregate_counter_updates` method that receives a block with DB updates happening within it. Users passing code as blocks to this method means they decide where the updates start and where they end and whether the aggregated SQL queries should be executed before or after commit.

```ruby
CounterCulture.aggregate_counter_updates do
  ActiveRecord::Base.transaction do
    # list of updates
  end
end # => executes aggregated SQLs after COMMIT
```

The method initialises some `Thread.current` variables:
`aggregate_counter_updates` - boolean, used to change how the `after_*` AR callbacks behave (store update instead of executing the SQL immediately)
`aggregated_updates` - object, stores the updates per table and target record
`primary_key_map` - object, stores the primary keys for every table

After the variables are initialised, the user-defined block is executed, which hopefully added some updates to `aggregated_updates`. It iterates through all updates and groups them into single SQLs per target record. The SQLs get executed.

After that, the variables are reset and the response of the user-defined block is returned.

If `Thread.current[:aggregate_counter_updates]` is `true`, `change_counter_cache` will no longer execute SQLs immediately (**except for Papertrail callbacks**), but rather:
- for counter cache columns - stores the value of the first update as a temporary counter in a `table -> record ID -> column to be updated/operation` key, which then gets incremented or decremented by subsequent updates of the same column of the same record in the same table. The final value of this temporary counter will be used in the final SQL query.
- for timestamps - stores the value of the first update as a temporary value in a `table -> record ID -> column to be updated/operation` key, which then gets overwritten by subsequent updates of the same column of the same record in the same table. Because there's a delay between the value added to the cache and the SQL being executed, I couldn't pass the timestamp as a string. I opted to pass the timestamp-generating logic as a block, so I could have the freshest timestamp for the SQL request.

I wrote the basic tests to see that everything works and cherry-picked some more complex scenarios to see if they pass with the aggregated logic. I think anything else would be a bit overkill, but let me know if I missed some tests 🤷‍♂️