### PR TITLE
Fix sqlite3 tests

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,8 @@
 ].each do |rails_version|
   appraise "rails-#{rails_version}" do
     gem 'rails', "~> #{rails_version}.0"
+    if Gem::Version.new(rails_version) < Gem::Version.new("7.2")
+      gem 'sqlite3', "~> 1.4"
+    end
   end
 end

--- a/counter_culture.gemspec
+++ b/counter_culture.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-extra-formatters'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'timecop'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', ">= 1.4"
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pg'
 end

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"


### PR DESCRIPTION
It turns out Rails versions prior to 7.2 require a `sqlite3 ~> 1.4` and we need to lock that in our `Gemfile` for the tests to work.
