### PR TITLE
Use `ActiveRecord.version` instead of `Rails.version`

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,7 +7,7 @@
   7.2
 ].each do |rails_version|
   appraise "rails-#{rails_version}" do
-    gem 'rails', "~> #{rails_version}.0"
+    gem 'activerecord', "~> #{rails_version}.0"
     if Gem::Version.new(rails_version) < Gem::Version.new("7.2")
       gem 'sqlite3', "~> 1.4"
     end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,7 +268,7 @@ Bugfixes:
 ## 1.8.1 (September 5, 2017)
 
 Improvements:
-  - Use ActiveRecord version, not Rails version, in `Reconciler`, makeing it possible to use `counter_culture_fix_counts` without Rails
+  - Use ActiveRecord version, not Rails version, in `Reconciler`, makeig it possible to use `counter_culture_fix_counts` without Rails
 
 ## 1.8.0 (August 30, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,7 +268,7 @@ Bugfixes:
 ## 1.8.1 (September 5, 2017)
 
 Improvements:
-  - Use ActiveRecord version, not Rails version, in `Reconciler`, makeig it possible to use `counter_culture_fix_counts` without Rails
+  - Use ActiveRecord version, not Rails version, in `Reconciler`, making it possible to use `counter_culture_fix_counts` without Rails
 
 ## 1.8.0 (August 30, 2017)
 

--- a/counter_culture.gemspec
+++ b/counter_culture.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'paper_trail'
   spec.add_development_dependency 'paranoia'
   spec.add_development_dependency 'after_commit_action'
-  spec.add_development_dependency 'rails', '>= 4.2'
+  spec.add_development_dependency 'activerecord', '>= 4.2'
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rdoc', ">= 6.3.1"
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.2.0"
+gem "activerecord", "~> 5.2.0"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0"
+gem "activerecord", "~> 6.0.0"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.1.0"
+gem "activerecord", "~> 6.1.0"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.0"
+gem "activerecord", "~> 7.0.0"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.1.0"
+gem "activerecord", "~> 7.1.0"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.2.0"
+gem "activerecord", "~> 7.2.0"
 
 gemspec path: "../"

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -181,17 +181,17 @@ module CounterCulture
       def log(message)
         return unless log?
 
-        Rails.logger.info(message)
+        ActiveRecord::Base.logger.info(message)
       end
 
       def log_without_newline(message)
         return unless log?
 
-        Rails.logger << message if Rails.logger.info?
+        ActiveRecord::Base.logger << message if ActiveRecord::Base.logger.info?
       end
 
       def log?
-        options[:verbose] && Rails.logger
+        options[:verbose] && ActiveRecord::Base.logger
       end
 
       # keep track of what we fixed, e.g. for a notification email

--- a/lib/counter_culture/with_connection.rb
+++ b/lib/counter_culture/with_connection.rb
@@ -23,11 +23,11 @@ module CounterCulture
     private
 
     def rails_7_1?
-      Gem::Requirement.new('~> 7.1.0').satisfied_by?(Gem::Version.new(Rails.version))
+      Gem::Requirement.new('~> 7.1.0').satisfied_by?(ActiveRecord.version)
     end
 
     def rails_7_2_or_greater?
-      Gem::Requirement.new('>= 7.2.0').satisfied_by?(Gem::Version.new(Rails.version))
+      Gem::Requirement.new('>= 7.2.0').satisfied_by?(ActiveRecord.version)
     end
   end
 end

--- a/lib/generators/counter_culture_generator.rb
+++ b/lib/generators/counter_culture_generator.rb
@@ -27,8 +27,8 @@ class CounterCultureGenerator < ActiveRecord::Generators::Base
   end
 
   def migration_version
-    if Gem::Version.new(Rails.version) >= Gem::Version.new('5.0.0')
-      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    if ActiveRecord.version >= Gem::Version.new('5.0.0')
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
     end
   end
 

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1581,10 +1581,10 @@ RSpec.describe "CounterCulture" do
   end
 
   it "should log if verbose option is true" do
-    logger = Rails.logger
+    logger = ActiveRecord::Base.logger
     io = StringIO.new
     io_logger = Logger.new(io)
-    Rails.logger = io_logger
+    ActiveRecord::Base.logger = io_logger
 
     # first, clean up
     SimpleDependent.delete_all
@@ -1609,7 +1609,7 @@ RSpec.describe "CounterCulture" do
       "Finished batch #2.")
     expect(io.string).to include(
       "Finished reconciling of SimpleDependent#simple_main.")
-    Rails.logger = logger
+    ActiveRecord::Base.logger = logger
   end
 
   MANY = CI_TEST_RUN ? 1000 : 20

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -21,7 +21,7 @@ class Review < ActiveRecord::Base
   after_create :update_read_only_text
 
   def update_some_text
-    return unless Gem::Version.new(Rails.version) >= Gem::Version.new('5.1.5')
+    return unless ActiveRecord.version >= Gem::Version.new('5.1.5')
     update_attribute(:some_text, rand(36**12).to_s(36))
   end
 

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
   default_scope do
     if _default_scope_enabled
       query = joins("LEFT OUTER JOIN companies ON users.company_id = companies.id")
-      Rails.version < "5.0.0" ? query.uniq : query.distinct
+      ActiveRecord.version < Gem::Version.new("5.0.0") ? query.uniq : query.distinct
     else
       all
     end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer :article_group_id, :null => false
   end
 
-  if ENV['DB'] == 'postgresql' && Gem::Version.new(Rails.version) >= Gem::Version.new('5.0')
+  if ENV['DB'] == 'postgresql' && ActiveRecord.version >= Gem::Version.new('5.0')
     create_table :purchase_orders, :force => true do |t|
       t.money "total_amount", scale: 2, default: "0.0", null: false
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'counter_culture'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'rails/all'
+require 'active_record'
 
 module PapertrailSupport
   def self.supported_here?
@@ -74,7 +74,7 @@ DB_CONFIG = {
   }
 }.with_indifferent_access.freeze
 
-if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
+if ActiveRecord.version < Gem::Version.new('5.0.0')
   ActiveRecord::Base.raise_in_transactional_callbacks = true
 end
 


### PR DESCRIPTION
Because it turns out that you can use ActiveRecord outside of Rails (today I learned!)
