### PR TITLE
Showcase of what is breaking for us in 3.10.0

### DIFF
--- a/spec/models/conversation.rb
+++ b/spec/models/conversation.rb
@@ -1,4 +1,8 @@
 class Conversation < ActiveRecord::Base
   belongs_to :candidate
+  delegate(
+    :candidate_profile,
+    to: :candidate
+  )
   counter_culture [:candidate, :candidate_profile]
 end


### PR DESCRIPTION
I have found a test change that showcases the issue we are experiencing. This breaks `spec/counter_culture_spec.rb:2077` on 3.10.0 but that test then passes with this new code after commenting out the new `assign_to_associated_object` call added in [this pr](https://github.com/magnusvk/counter_culture/pull/407).

Not 100% sure yet why this change breaks this implementation (delegations on multi level counter caches)