### PR TITLE
feat: allow composite primary keys for Rails v7.2+

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -35,9 +35,16 @@ module CounterCulture
         end.compact
 
         if update_snippets.any?
-          klass
-            .where(Thread.current[:primary_key_map][klass] => rec_id)
-            .update_all(update_snippets.join(', '))
+          primary_key = Thread.current[:primary_key_map][klass]
+          if primary_key.is_a?(Array)
+            conditions = {}
+            primary_key.each_with_index do |key, index|
+              conditions[key] = rec_id[index]
+            end
+            klass.where(conditions).update_all(update_snippets.join(', '))
+          else
+            klass.where(primary_key => rec_id).update_all(update_snippets.join(', '))
+          end
         end
       end
     end

--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -36,15 +36,13 @@ module CounterCulture
 
         if update_snippets.any?
           primary_key = Thread.current[:primary_key_map][klass]
-          if primary_key.is_a?(Array)
-            conditions = {}
-            primary_key.each_with_index do |key, index|
-              conditions[key] = rec_id[index]
-            end
-            klass.where(conditions).update_all(update_snippets.join(', '))
-          else
-            klass.where(primary_key => rec_id).update_all(update_snippets.join(', '))
-          end
+
+          conditions =
+            Array.wrap(primary_key)
+                .zip(Array.wrap(rec_id))
+                .to_h
+
+          klass.where(conditions).update_all(update_snippets.join(', '))
         end
       end
     end

--- a/lib/counter_culture/configuration.rb
+++ b/lib/counter_culture/configuration.rb
@@ -11,6 +11,10 @@ module CounterCulture
     @configuration = Configuration.new
   end
 
+  def self.supports_composite_keys?
+    Gem::Requirement.new('>= 7.2.0').satisfied_by?(ActiveRecord.version)
+  end
+
   class Configuration
     attr_reader :use_read_replica
 

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -185,12 +185,7 @@ module CounterCulture
 
     # the string to pass to order() in order to sort by primary key
     def full_primary_key(klass)
-      primary_key = klass.primary_key
-      if primary_key.is_a?(Array)
-        primary_key.map { |pk| "#{klass.quoted_table_name}.#{pk}" }.join(', ')
-      else
-        "#{klass.quoted_table_name}.#{klass.quoted_primary_key}"
-      end
+      Array.wrap(primary_key).map { |pk| "#{klass.quoted_table_name}.#{pk}" }.join(', ')
     end
 
     # gets the value of the foreign key on the given relation

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -314,11 +314,6 @@ module CounterCulture
         return relation_klass(relation, source: source, was: was).try(:primary_key)
       end
 
-      # handle composite primary keys
-      if reflect.options[:primary_key].is_a?(Array)
-        return reflect.options[:primary_key]
-      end
-
       reflect.association_primary_key(klass)
     end
 

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -176,7 +176,7 @@ module CounterCulture
 
     # the string to pass to order() in order to sort by primary key
     def full_primary_key(klass)
-      Array.wrap(klass.primary_key).map { |pk| "#{klass.quoted_table_name}.#{pk}" }.join(', ')
+      Array.wrap(klass.quoted_primary_key).map { |pk| "#{klass.quoted_table_name}.#{pk}" }.join(', ')
     end
 
     # gets the value of the foreign key on the given relation

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -207,7 +207,7 @@ module CounterCulture
       end
 
       primary_key = relation_primary_key(original_relation, source: obj, was: was)
-      Array.wrap(primary_key).filter_map { |pk| value.try(pk&.to_sym) }.presence
+      Array.wrap(primary_key).map { |pk| value.try(pk&.to_sym) }.compact.presence
     end
 
     # gets the reflect object on the given relation

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -61,7 +61,6 @@ module CounterCulture
 
       delegate :model, :relation, :full_primary_key, :relation_reflect, :polymorphic?, :to => :counter
       delegate *CounterCulture::Counter::CONFIG_OPTIONS, :to => :counter
-      delegate :primary_key, :to => :relation_class
 
       def initialize(counter, changes_holder, options, relation_class)
         @counter, @options, = counter, options
@@ -174,7 +173,7 @@ module CounterCulture
             end
 
             with_writing_db_connection do
-              conditions = Array.wrap(primary_key).map { |key| [key, record.send(key)] }.to_h
+              conditions = Array.wrap(relation_class.primary_key).map { |key| [key, record.send(key)] }.to_h
               relation_class.where(conditions).update_all(updates.join(', '))
             end
           end
@@ -205,7 +204,7 @@ module CounterCulture
           :wrong => record.send(column_name),
           :right => count
         }.tap do |h|
-          Array.wrap(primary_key).each { |pk| h[pk.to_sym] = record.send(pk) }
+          Array.wrap(relation_class.primary_key).each { |pk| h[pk.to_sym] = record.send(pk) }
         end
       end
 
@@ -228,7 +227,7 @@ module CounterCulture
 
       def primary_key_select
         relation_class_table_name = quote_table_name(relation_class.table_name)
-        Array.wrap(primary_key).map { |pk| "#{relation_class_table_name}.#{pk}" }.join(', ')
+        Array.wrap(relation_class.primary_key).map { |pk| "#{relation_class_table_name}.#{pk}" }.join(', ')
       end
 
       def association_primary_key_select

--- a/lib/counter_culture/reconciler.rb
+++ b/lib/counter_culture/reconciler.rb
@@ -287,17 +287,16 @@ module CounterCulture
               [target_table_key, source_table_key]
           end
 
-          if source_table_key.is_a?(Array) && target_table_key.is_a?(Array)
-            # handle composite primary keys
-            join_conditions = source_table_key.zip(target_table_key).map do |source_key, target_key|
-              "#{source_table}.#{source_key} = #{target_table_alias}.#{target_key}"
-            end
-            joins_sql = "LEFT JOIN #{target_table} AS #{target_table_alias} "\
-              "ON #{join_conditions.join(' AND ')}"
-          else
-            joins_sql = "LEFT JOIN #{target_table} AS #{target_table_alias} "\
-              "ON #{source_table}.#{source_table_key} = #{target_table_alias}.#{target_table_key}"
-          end
+          source_table_key = Array.wrap(source_table_key)
+          target_table_key = Array.wrap(target_table_key)
+
+          join_conditions =
+            source_table_key
+              .zip(target_table_key).map do |source_key, target_key|
+                "#{source_table}.#{source_key} = #{target_table_alias}.#{target_key}"
+              end.join(' AND ')
+          joins_sql = "LEFT JOIN #{target_table} AS #{target_table_alias} "\
+            "ON #{join_conditions}"
 
           # adds 'type' condition to JOIN clause if the current model is a
           # child in a Single Table Inheritance

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -39,6 +39,13 @@ require 'models/group_item'
 require 'models/article_group'
 require 'models/article'
 
+if CounterCulture.supports_composite_keys?
+  require 'models/composite_group'
+  require 'models/composite_group_user'
+  require 'models/composite_user'
+end
+
+
 if ENV['DB'] == 'postgresql'
   require 'models/purchase_order'
   require 'models/purchase_order_item'
@@ -2807,6 +2814,33 @@ RSpec.describe "CounterCulture" do
       expect(user.reviews_count).to eq(1)
       expect(user.versions.count).to eq(1)
     end
+
+    context "with composite primary keys" do
+      before do
+        unless PapertrailSupport.supported_here?
+          skip("Unsupported in this combination of Ruby and Rails")
+        end
+
+        unless CounterCulture.supports_composite_keys?
+          skip("composite primary keys are not supported in this version of Rails")
+        end
+      end
+
+      it "increments / decrements counter caches correctly" do
+        group = CompositeGroup.create!(secondary_id: 123)
+
+        expect(group.composite_users_count).to eq(0)
+        expect(group.composite_users.count).to eq(0)
+        group.composite_users << CompositeUser.create!
+
+        expect(group.composite_users.count).to eq(1)
+        expect(group.composite_users_count).to eq(1)
+        group.composite_users.first.destroy
+
+        group.reload
+        expect(group.composite_users_count).to eq(0)
+      end
+    end
   end
 
   describe "with a module for the model" do
@@ -3026,6 +3060,51 @@ RSpec.describe "CounterCulture" do
     post = Post.create!
     Timecop.travel(2.second.from_now) do
       expect { PostLike.create!(post: post) }.to change { post.reload.updated_at }
+    end
+  end
+
+  context "with composite primary keys" do
+    before do
+      unless CounterCulture.supports_composite_keys?
+        skip("composite primary keys not supported in this version of Rails")
+      end
+    end
+
+    it "should increment / decrement the counter" do
+      group = CompositeGroup.create!(secondary_id: 123)
+
+      expect(group.composite_users.count).to eq(0)
+      expect(group.composite_users_count).to eq(0)
+      group.composite_users << CompositeUser.create!
+
+      expect(group.composite_users.count).to eq(1)
+      expect(group.composite_users_count).to eq(1)
+      group.composite_users.first.destroy
+
+      group.reload
+      expect(group.composite_users_count).to eq(0)
+    end
+
+    it "should fix the counter caches" do
+      group = CompositeGroup.create!(secondary_id: 123)
+      user1 = CompositeUser.create!
+      user2 = CompositeUser.create!
+
+      group.composite_users << user1
+      group.composite_users << user2
+
+      expect(group.composite_users_count).to eq(2)
+
+      # mess up the count
+      group.update_column(:composite_users_count, -1)
+      user1.update_column(:composite_groups_count, -1)
+
+      CompositeGroupUser.counter_culture_fix_counts
+
+      group.reload
+      user1.reload
+      expect(group.composite_users_count).to eq(2)
+      expect(user1.composite_groups_count).to eq(1)
     end
   end
 
@@ -3374,6 +3453,88 @@ RSpec.describe "CounterCulture" do
 
       po.reload
       expect(po.total_amount).to eq(0.0)
+    end
+
+    context "with composite primary keys" do
+      before do
+      unless CounterCulture.supports_composite_keys?
+          skip("composite primary keys not supported in this version of Rails")
+        end
+      end
+
+      it "increments / decrements the counter cache" do
+        group = CompositeGroup.create!(secondary_id: 123)
+        user1 = CompositeUser.create!
+        user2 = CompositeUser.create!
+
+        expect(group.composite_users_count).to eq(0)
+
+        group_user1 = CounterCulture.aggregate_counter_updates do
+          CompositeGroupUser.create!(
+            composite_group_id: group.id,
+            secondary_id: group.secondary_id,
+            composite_user_id: user1.id
+          )
+        end
+
+        group.reload
+        expect(group.composite_users_count).to eq(1)
+
+        group_user2 = CounterCulture.aggregate_counter_updates do
+          CompositeGroupUser.create!(
+            composite_group_id: group.id,
+            secondary_id: group.secondary_id,
+            composite_user_id: user2.id
+          )
+        end
+
+        group.reload
+        expect(group.composite_users_count).to eq(2)
+
+        CounterCulture.aggregate_counter_updates do
+          group_user1.destroy!
+        end
+
+        group.reload
+        expect(group.composite_users_count).to eq(1)
+
+        CounterCulture.aggregate_counter_updates do
+          group_user2.destroy!
+        end
+
+        group.reload
+        expect(group.composite_users_count).to eq(0)
+      end
+
+      it "optimizes SQL queries when aggregating updates" do
+        group = CompositeGroup.create!(secondary_id: 123)
+        user1 = CompositeUser.create!
+        user2 = CompositeUser.create!
+        user3 = CompositeUser.create!
+
+        expect(group.composite_users_count).to eq(0)
+
+        # with aggregation, this should generate only 1 UPDATE query for the group
+        expect_queries(1, filter: /UPDATE composite_groups/) do
+          CounterCulture.aggregate_counter_updates do
+            CompositeGroupUser.create!(
+              composite_group_id: group.id,
+              secondary_id: group.secondary_id,
+              composite_user_id: user1.id
+            )
+            CompositeGroupUser.create!(
+              composite_group_id: group.id,
+              secondary_id: group.secondary_id,
+              composite_user_id: user2.id
+            )
+            CompositeGroupUser.create!(
+              composite_group_id: group.id,
+              secondary_id: group.secondary_id,
+              composite_user_id: user3.id
+            )
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/composite_group.rb
+++ b/spec/models/composite_group.rb
@@ -1,0 +1,12 @@
+class CompositeGroup < ActiveRecord::Base
+  has_many :composite_group_users,
+    primary_key: [:id, :secondary_id],
+    foreign_key: [:composite_group_id, :secondary_id]
+
+  has_many :composite_users,
+    through: :composite_group_users
+
+  if PapertrailSupport.supported_here?
+    has_paper_trail
+  end
+end

--- a/spec/models/composite_group_user.rb
+++ b/spec/models/composite_group_user.rb
@@ -1,0 +1,12 @@
+class CompositeGroupUser < ActiveRecord::Base
+  belongs_to :composite_group,
+    primary_key: [:id, :secondary_id],
+    foreign_key: [:composite_group_id, :secondary_id]
+  belongs_to :composite_user
+
+  counter_culture :composite_group, column_name: 'composite_users_count'
+  counter_culture :composite_group, column_name: 'composite_users_pt_count',
+    :with_papertrail => PapertrailSupport.supported_here?
+
+  counter_culture :composite_user, column_name: 'composite_groups_count'
+end

--- a/spec/models/composite_user.rb
+++ b/spec/models/composite_user.rb
@@ -1,0 +1,5 @@
+class CompositeUser < ActiveRecord::Base
+  has_many :composite_group_users, dependent: :destroy
+  has_many :composite_groups,
+    through: :composite_group_users
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -315,6 +315,22 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer :article_group_id, :null => false
   end
 
+  create_table "composite_groups", :force => true do |t|
+    t.integer :secondary_id, :null => false
+    t.integer :composite_users_count, :default => 0, :null => false
+    t.integer :composite_users_pt_count, :default => 0, :null => false
+  end
+
+  create_table "composite_group_users", :force => true do |t|
+    t.integer :composite_user_id, :null => false
+    t.integer :composite_group_id, :null => false
+    t.integer :secondary_id, :null => false
+  end
+
+  create_table "composite_users", :force => true do |t|
+    t.integer :composite_groups_count, :default => 0, :null => false
+  end
+
   if ENV['DB'] == 'postgresql' && ActiveRecord.version >= Gem::Version.new('5.0')
     create_table :purchase_orders, :force => true do |t|
       t.money "total_amount", scale: 2, default: "0.0", null: false


### PR DESCRIPTION
Fixes #412 

This change allows `counter_culture` to be used for associations that make use of `primary_key/foreign_key` with array values.

I tested that this change doesn't affect backwards compatibility of existing functionality for older versions of activerecord, but the test setup is reliant on the format of composite primary keys supported in activerecord v7.2+.

Also this change is functional with and has tests for composite key functionality with:
- papertrail
- `aggregate_counter_updates`
- `counter_culture_fix_counts`