### PR TITLE
fix: Skip assigning counter to associated objects when referencing past values

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -138,7 +138,9 @@ module CounterCulture
         unless Thread.current[:aggregate_counter_updates]
           execute_now_or_after_commit(obj) do
             klass.where(primary_key => id_to_change).update_all updates.join(', ')
-            assign_to_associated_object(obj, relation, change_counter_column, operator, delta_magnitude)
+            unless options[:was]
+              assign_to_associated_object(obj, relation, change_counter_column, operator, delta_magnitude)
+            end
           end
         end
       end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -125,6 +125,25 @@ RSpec.describe "CounterCulture" do
     expect(product.reviews_count).to eq(1)
   end
 
+  it "updates counter caches on change belongs_to association" do
+    simple_main1 = SimpleMain.create
+    simple_main2 = SimpleMain.create
+    simple_dependent = SimpleDependent.create :simple_main_id => simple_main1.id
+
+    simple_dependent.simple_main = simple_main2
+    simple_dependent.save!
+
+    expect(simple_main1.simple_dependents_count).to eq(0)
+    expect(simple_main2.simple_dependents_count).to eq(1)
+
+    # NOTE: check if counters from the DB equal to the cached
+    simple_main1.reload
+    simple_main2.reload
+
+    expect(simple_main1.simple_dependents_count).to eq(0)
+    expect(simple_main2.simple_dependents_count).to eq(1)
+  end
+
   it "skips zero delta_magnitude update on create" do
     user = User.create
     product = Product.create


### PR DESCRIPTION
fixed: https://github.com/magnusvk/counter_culture/issues/414

When `options[:was]` is true (referencing past values), skip assigning the counter value to associated objects. 
This prevents unnecessary counter assignments when referencing past values.