### PR TITLE
fix: FrozenError when associated instance is frozen

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -378,7 +378,7 @@ module CounterCulture
       association_name = relation_reflect(relation).name
 
       association_object = association_object_for_assign(obj, association_name)
-      return if association_object.blank?
+      return if association_object.blank? || association_object.frozen?
 
       association_object.assign_attributes(
         change_counter_column =>


### PR DESCRIPTION
Hi @magnusvk 

After the v3.10.0 of this change https://github.com/magnusvk/counter_culture/pull/407 we encountered the `FrozenError:
       can't modify frozen attributes` error while the create/destroy. Because we have frozen associated object instance while counter_culture attempt update the attribute of instance.

This pull-request fix the issue and add test about it.