### PR TITLE
Fix regression for `foreign_key_values` by adding support for composite primary keys

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -108,6 +108,15 @@ module CounterCulture
 
         primary_key = relation_primary_key(relation, source: obj, was: options[:was])
 
+        if foreign_key_values && id_to_change.is_a?(Enumerable) && id_to_change.count > 1 &&
+            Array.wrap(primary_key).count == 1
+          # To keep this feature backwards compatible, we need to accommodate a case where
+          # `foreign_key_values` returns an array, but we're _not_ using composite primary
+          # keys. In that case, we need to wrap the `id_to_change` in one more array to keep
+          # it compatible with the `.zip` call in `primary_key_conditions`.
+          id_to_change = [id_to_change]
+        end
+
         if Thread.current[:aggregate_counter_updates]
           Thread.current[:primary_key_map][klass] ||= primary_key
         end

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -1232,34 +1232,34 @@ RSpec.describe "CounterCulture" do
   end
 
   it "should overwrite foreign-key values on create" do
-    3.times { Category.create }
-    Category.all {|category| expect(category.products_count).to eq(0) }
+    categories = 3.times.map { Category.create }
+    categories.each {|category| expect(category.products_count).to eq(0) }
 
     product = Product.create :category_id => Category.first.id
-    Category.all {|category| expect(category.products_count).to eq(1) }
+    categories.each {|category| expect(category.reload.products_count).to eq(1) }
   end
 
   it "should overwrite foreign-key values on destroy" do
-    3.times { Category.create }
-    Category.all {|category| expect(category.products_count).to eq(0) }
+    categories = 3.times.map { Category.create }
+    categories.each {|category| expect(category.products_count).to eq(0) }
 
     product = Product.create :category_id => Category.first.id
-    Category.all {|category| expect(category.products_count).to eq(1) }
+    categories.each {|category| expect(category.reload.products_count).to eq(1) }
 
     product.destroy
-    Category.all {|category| expect(category.products_count).to eq(0) }
+    categories.each {|category| expect(category.reload.products_count).to eq(0) }
   end
 
   it "should overwrite foreign-key values on destroy" do
-    3.times { Category.create }
-    Category.all {|category| expect(category.products_count).to eq(0) }
+    categories = 3.times.map { Category.create }
+    categories.each {|category| expect(category.products_count).to eq(0) }
 
     product = Product.create :category_id => Category.first.id
-    Category.all {|category| expect(category.products_count).to eq(1) }
+    categories.each {|category| expect(category.reload.products_count).to eq(1) }
 
     product.category = nil
     product.save!
-    Category.all {|category| expect(category.products_count).to eq(0) }
+    categories.each {|category| expect(category.reload.products_count).to eq(0) }
   end
 
   it "should not report correct counts when fix_counts is called" do

--- a/spec/models/product.rb
+++ b/spec/models/product.rb
@@ -1,7 +1,13 @@
 class Product < ActiveRecord::Base
   belongs_to :category
 
-  counter_culture :category, :foreign_key_values => proc {|foreign_key_value| Category.pluck(:id) }
+  counter_culture :category, :foreign_key_values => lambda { |foreign_key_value|
+    if foreign_key_value.present?
+      Category.pluck(:id)
+    else
+      nil
+    end
+  }
 
   if PapertrailSupport.supported_here?
     has_paper_trail


### PR DESCRIPTION
It turns out the old tests here weren't properly reloading and thus didn't catch this regression.