### PR TITLE
Demonstrate broken counter in after update callback

### DIFF
--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -38,6 +38,7 @@ require 'models/sub_group'
 require 'models/group_item'
 require 'models/article_group'
 require 'models/article'
+require 'models/moderated_review'
 
 if CounterCulture.supports_composite_keys?
   require 'models/composite_group'
@@ -254,6 +255,18 @@ RSpec.describe "CounterCulture" do
     user.reload
 
     expect(user.review_approvals_count).to eq(26)
+  end
+
+  context 'when state changes in update callback update' do
+    it 'should increments counter cache once' do
+      user = User.create
+      moderate_review = ModeratedReview.create :user_id => user.id
+      moderate_review.update(up: true)
+      user.reload
+      moderate_review.reload
+
+      expect(user.approved_positive_reviews_count).to eq(1)
+    end
   end
 
   it "skips increments counter cache on destroy" do

--- a/spec/models/moderated_review.rb
+++ b/spec/models/moderated_review.rb
@@ -1,0 +1,19 @@
+class ModeratedReview < ActiveRecord::Base
+  belongs_to :user
+
+  after_update :auto_approve
+
+  counter_culture :user, :column_name => -> (review) { review.positive_and_approved? ? 'approved_positive_reviews_count' : nil }
+  def positive_and_approved?
+    up? && approved?
+  end
+
+  private
+
+  def auto_approve
+    unless approved?
+      self.approved = true
+      save
+    end
+  end
+end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -13,6 +13,8 @@ class User < ActiveRecord::Base
   has_many :reviews
   accepts_nested_attributes_for :reviews, :allow_destroy => true
 
+  has_many :moderated_reviews
+
   if PapertrailSupport.supported_here?
     has_paper_trail
   end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -92,9 +92,18 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.integer  "dynamic_delta_count",         :default => 0, :null => false
     t.integer  "custom_delta_count",         :default => 0, :null => false
     t.integer  "review_approvals_count",      :default => 0, :null => false
+    t.integer  "approved_positive_reviews_count",      :default => 0, :null => false
     t.string   "has_string_id_id"
     t.integer  "has_non_pk_id_id"
     t.float    "review_value_sum",    :default => 0.0, :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "moderated_reviews", :force => true do |t|
+    t.integer "user_id"
+    t.boolean "up"
+    t.boolean "approved"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
Hello! 
I found a problem with updating the counter when the record is saved in the after_update callback.

The counter is updated twice because _update_counts_after_update is called twice

I added a sample test in the PR