### PR TITLE
Fix counter cache not using the correct type with multiple STI models in the association chain

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -240,11 +240,11 @@ module CounterCulture
       Array.wrap(primary_key).map { |pk| value.try(pk&.to_sym) }.compact.presence
     end
 
-    # gets the reflect object on the given relation
+    # gets the reflect object on the given relation and the model that defines this reflect
     #
     # relation: a symbol or array of symbols; specifies the relation
     #   that has the counter cache column
-    def relation_reflect(relation)
+    def relation_reflect_and_model(relation)
       relation = relation.is_a?(Enumerable) ? relation.dup : [relation]
 
       # go from one relation to the next until we hit the last reflect object
@@ -262,7 +262,16 @@ module CounterCulture
         end
       end
 
-      return reflect
+      return [reflect, klass]
+    end
+
+
+    # gets the reflect object on the given relation
+    #
+    # relation: a symbol or array of symbols; specifies the relation
+    #   that has the counter cache column
+    def relation_reflect(relation)
+      relation_reflect_and_model(relation).first
     end
 
     # gets the class of the given relation

--- a/spec/models/admin_user.rb
+++ b/spec/models/admin_user.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class AdminUser < User
+end

--- a/spec/models/review.rb
+++ b/spec/models/review.rb
@@ -1,6 +1,7 @@
 class Review < ActiveRecord::Base
-  belongs_to :user
-  belongs_to :product
+  belongs_to :user, optional: true
+  belongs_to :admin_user, optional: true
+  belongs_to :product, optional: true
 
   counter_culture :product, :touch => true, :with_papertrail => PapertrailSupport.supported_here?
   counter_culture :product, :column_name => 'rexiews_count', touch: :rexiews_updated_at

--- a/spec/models/twitter_review.rb
+++ b/spec/models/twitter_review.rb
@@ -2,5 +2,6 @@ class TwitterReview < Review
   counter_culture :product, column_name: 'twitter_reviews_count'
 
   counter_culture [:user, :manages_company]
+  counter_culture [:admin_user, :manages_company], :column_name => 'admin_reviews_count'
 
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.string   "name"
     t.integer  "industry_id"
     t.integer  "reviews_count",       :default => 0, :null => false
+    t.integer  "admin_reviews_count",       :default => 0, :null => false
     t.integer  "twitter_reviews_count",       :default => 0, :null => false
     t.integer  "using_count",         :default => 0, :null => false
     t.integer  "tried_count",         :default => 0, :null => false
@@ -73,6 +74,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.string   "some_text"
     t.string   "read_only_text"
     t.integer  "user_id"
+    t.integer  "admin_user_id"
     t.integer  "product_id"
     t.integer  "approvals"
     t.float    "value"
@@ -83,6 +85,7 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
   end
 
   create_table "users", :force => true do |t|
+    t.string   "type"
     t.string   "name"
     t.integer  "company_id"
     t.integer  "manages_company_id"


### PR DESCRIPTION
Before this PR `CounterCulture::Reconciler` didn't handle having STI models in the middle of association chain correctly if the model that defines counter cache is also STI model. When generating join queries it would use `type = "[model.type]"`, but `[model.type]` would always be the type of the model that called `counter_culture_fix_counts`.

For example:
```ruby
class AdminUser < User
  belongs_to :manages_company
end

class TwitterReview < Review
  belongs_to :admin_user
  counter_culture [:admin_user, :manages_company]
```

The first join will be generated incorrectly:
```SQL
FROM companies
LEFT JOIN users ON companies.id = users.managed_company_id AND users.type = "TwitterReview"
LEFT JOIN reviews ON users.id = reviews.admin_user_id AND reviews.type = "TwitterReview"
```

This PR fixes it by setting correct `model` for each relation, so the same query becomes:

```SQL
FROM companies
LEFT JOIN users ON companies.id = users.managed_company_id AND users.type = "AdminUser"
LEFT JOIN reviews ON users.id = reviews.admin_user_id AND reviews.type = "TwitterReview"
```

Since it sets `model` local variable in `Reconciler`, this should also fix intermediate models that were `paranoia` or `discard` deleted, but would still be joined in the join query, though I don't use either so I haven't tested this interaction.