### PR TITLE
Fix StaleObjectError when counter target model has optimistic locking

### DIFF
--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -46,8 +46,7 @@ module CounterCulture
         end
 
         if arel_updates.any?
-          # Prevent Rails 8.1+ from auto-incrementing lock_version
-          # (same rationale as in Counter#change_counter_cache)
+          # Set lock_version = lock_version (no-op) to skip Rails auto-increment
           if klass.locking_enabled?
             lc = klass.locking_column
             arel_updates[lc] = klass.arel_table[lc]

--- a/lib/counter_culture.rb
+++ b/lib/counter_culture.rb
@@ -46,6 +46,13 @@ module CounterCulture
         end
 
         if arel_updates.any?
+          # Prevent Rails 8.1+ from auto-incrementing lock_version
+          # (same rationale as in Counter#change_counter_cache)
+          if klass.locking_enabled?
+            lc = klass.locking_column
+            arel_updates[lc] = klass.arel_table[lc]
+          end
+
           primary_key = Thread.current[:primary_key_map][klass]
 
           conditions =

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -75,12 +75,7 @@ module CounterCulture
           counter_expr = Counter.build_arel_counter_expr(klass, change_counter_column, signed_delta, column_type)
           arel_updates = { change_counter_column => counter_expr }
 
-          # Prevent Rails 8.1+ from auto-incrementing lock_version in hash-based
-          # update_all (see ActiveRecord::Relation#update_all). Counter updates are
-          # atomic SQL operations (SET col = col + 1) that don't need optimistic
-          # locking protection. Without this, the DB lock_version gets silently
-          # incremented while in-memory objects retain the old value, causing
-          # StaleObjectError on subsequent touch/save operations.
+          # Set lock_version = lock_version (no-op) to skip Rails auto-increment
           if klass.locking_enabled?
             lc = klass.locking_column
             arel_updates[lc] = klass.arel_table[lc]

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -74,6 +74,17 @@ module CounterCulture
           # Build Arel expression for non-aggregate case
           counter_expr = Counter.build_arel_counter_expr(klass, change_counter_column, signed_delta, column_type)
           arel_updates = { change_counter_column => counter_expr }
+
+          # Prevent Rails 8.1+ from auto-incrementing lock_version in hash-based
+          # update_all (see ActiveRecord::Relation#update_all). Counter updates are
+          # atomic SQL operations (SET col = col + 1) that don't need optimistic
+          # locking protection. Without this, the DB lock_version gets silently
+          # incremented while in-memory objects retain the old value, causing
+          # StaleObjectError on subsequent touch/save operations.
+          if klass.locking_enabled?
+            lc = klass.locking_column
+            arel_updates[lc] = klass.arel_table[lc]
+          end
         end
 
         # and this will update the timestamp, if so desired

--- a/spec/counter_culture_spec.rb
+++ b/spec/counter_culture_spec.rb
@@ -41,6 +41,10 @@ require 'models/article_group'
 require 'models/article'
 require 'models/sti_contract/agreement'
 require 'models/sti_contract/base'
+require 'models/locking_parent'
+require 'models/locking_child'
+require 'models/locking_touch_child'
+require 'models/locking_grandchild'
 
 if CounterCulture.supports_composite_keys?
   require 'models/composite_group'
@@ -4108,6 +4112,187 @@ RSpec.describe "CounterCulture" do
 
       agreement.reload
       expect(agreement.contracts_count).to eq(2)
+    end
+  end
+
+  describe "with optimistic locking" do
+    describe "should not increment lock_version on counter update" do
+      it "on create" do
+        parent = LockingParent.create!
+        LockingChild.create!(:locking_parent => parent)
+        parent.reload
+
+        expect(parent.children_count).to eq(1)
+        expect(parent.lock_version).to eq(0)
+      end
+
+      it "on destroy" do
+        parent = LockingParent.create!
+        child = LockingChild.create!(:locking_parent => parent)
+        child.destroy!
+        parent.reload
+
+        expect(parent.children_count).to eq(0)
+        expect(parent.lock_version).to eq(0)
+      end
+
+      it "with multiple children" do
+        parent = LockingParent.create!
+        5.times { LockingChild.create!(:locking_parent => parent) }
+        parent.reload
+
+        expect(parent.children_count).to eq(5)
+        expect(parent.lock_version).to eq(0)
+      end
+
+      it "on update that changes parent" do
+        parent1 = LockingParent.create!
+        parent2 = LockingParent.create!
+        child = LockingChild.create!(:locking_parent => parent1)
+
+        child.update!(:locking_parent => parent2)
+        parent1.reload
+        parent2.reload
+
+        expect(parent1.children_count).to eq(0)
+        expect(parent1.lock_version).to eq(0)
+        expect(parent2.children_count).to eq(1)
+        expect(parent2.lock_version).to eq(0)
+      end
+
+      it "with multi-level counter" do
+        parent = LockingParent.create!
+        child = LockingChild.create!(:locking_parent => parent)
+        LockingGrandchild.create!(:locking_child => child)
+        parent.reload
+
+        expect(parent.grandchildren_count).to eq(1)
+        expect(parent.lock_version).to eq(0)
+      end
+
+      it "with aggregate counter updates" do
+        parent = LockingParent.create!
+
+        CounterCulture.aggregate_counter_updates do
+          3.times { LockingChild.create!(:locking_parent => parent) }
+        end
+
+        parent.reload
+        expect(parent.children_count).to eq(3)
+        expect(parent.lock_version).to eq(0)
+      end
+
+      it "with multi-level aggregate counter updates" do
+        parent = LockingParent.create!
+        child = LockingChild.create!(:locking_parent => parent)
+
+        CounterCulture.aggregate_counter_updates do
+          3.times { LockingGrandchild.create!(:locking_child => child) }
+        end
+
+        parent.reload
+        expect(parent.grandchildren_count).to eq(3)
+        expect(parent.lock_version).to eq(0)
+      end
+    end
+
+    describe "should not raise StaleObjectError with touch: true on belongs_to" do
+      it "on create" do
+        parent = LockingParent.create!
+        expect { LockingTouchChild.create!(:locking_parent => parent) }.not_to raise_error
+        expect(parent.reload.children_count).to eq(1)
+      end
+
+      it "on destroy" do
+        parent = LockingParent.create!
+        child = LockingTouchChild.create!(:locking_parent => parent)
+        expect { child.destroy! }.not_to raise_error
+        expect(parent.reload.children_count).to eq(0)
+      end
+
+      it "with multiple children" do
+        parent = LockingParent.create!
+        expect {
+          5.times { LockingTouchChild.create!(:locking_parent => parent) }
+        }.not_to raise_error
+        expect(parent.reload.children_count).to eq(5)
+      end
+
+      it "allows touch on parent after counter update" do
+        parent = LockingParent.create!
+        LockingTouchChild.create!(:locking_parent => parent)
+        expect { parent.touch }.not_to raise_error
+      end
+
+      it "allows save on parent after counter update" do
+        parent = LockingParent.create!(:name => "original")
+        LockingTouchChild.create!(:locking_parent => parent)
+
+        parent.name = "updated"
+        expect { parent.save! }.not_to raise_error
+        expect(parent.reload.name).to eq("updated")
+      end
+
+      it "allows multiple touches after multiple counter updates" do
+        parent = LockingParent.create!
+        3.times { LockingTouchChild.create!(:locking_parent => parent) }
+
+        expect { parent.touch }.not_to raise_error
+        expect { parent.touch }.not_to raise_error
+      end
+
+      it "allows touch after create and destroy cycle" do
+        parent = LockingParent.create!
+        child = LockingTouchChild.create!(:locking_parent => parent)
+        child.destroy!
+
+        expect { parent.touch }.not_to raise_error
+        expect(parent.reload.children_count).to eq(0)
+      end
+
+      it "with aggregate counter updates" do
+        parent = LockingParent.create!
+
+        CounterCulture.aggregate_counter_updates do
+          3.times { LockingTouchChild.create!(:locking_parent => parent) }
+        end
+
+        expect { parent.touch }.not_to raise_error
+        expect(parent.reload.children_count).to eq(3)
+      end
+    end
+
+    describe "should preserve normal optimistic locking behavior" do
+      it "increments lock_version on regular save" do
+        parent = LockingParent.create!
+        parent.update!(:name => "updated")
+        expect(parent.lock_version).to eq(1)
+      end
+
+      it "increments lock_version on touch" do
+        parent = LockingParent.create!
+        parent.touch
+        expect(parent.lock_version).to eq(1)
+      end
+
+      it "raises StaleObjectError on concurrent edits" do
+        parent = LockingParent.create!
+        stale_parent = LockingParent.find(parent.id)
+
+        parent.update!(:name => "first edit")
+        expect {
+          stale_parent.update!(:name => "second edit")
+        }.to raise_error(ActiveRecord::StaleObjectError)
+      end
+
+      it "increments lock_version via touch: true from child, not from counter" do
+        parent = LockingParent.create!
+        LockingTouchChild.create!(:locking_parent => parent)
+        parent.reload
+
+        expect(parent.lock_version).to eq(1)
+        expect(parent.children_count).to eq(1)
+      end
     end
   end
 end

--- a/spec/models/locking_child.rb
+++ b/spec/models/locking_child.rb
@@ -1,0 +1,6 @@
+class LockingChild < ActiveRecord::Base
+  belongs_to :locking_parent
+  has_many :locking_grandchildren
+
+  counter_culture :locking_parent, :column_name => :children_count
+end

--- a/spec/models/locking_grandchild.rb
+++ b/spec/models/locking_grandchild.rb
@@ -1,0 +1,6 @@
+class LockingGrandchild < ActiveRecord::Base
+  belongs_to :locking_child
+
+  counter_culture :locking_child, :column_name => :grandchildren_count
+  counter_culture [:locking_child, :locking_parent], :column_name => :grandchildren_count
+end

--- a/spec/models/locking_parent.rb
+++ b/spec/models/locking_parent.rb
@@ -1,0 +1,4 @@
+class LockingParent < ActiveRecord::Base
+  has_many :locking_children
+  has_many :locking_grandchildren, through: :locking_children
+end

--- a/spec/models/locking_touch_child.rb
+++ b/spec/models/locking_touch_child.rb
@@ -1,0 +1,8 @@
+class LockingTouchChild < ActiveRecord::Base
+  self.table_name = "locking_children"
+
+  belongs_to :locking_parent, :touch => true
+  has_many :locking_grandchildren, :foreign_key => :locking_child_id
+
+  counter_culture :locking_parent, :column_name => :children_count
+end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -364,4 +364,26 @@ ActiveRecord::Schema.define(:version => 20120522160158) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "locking_parents", :force => true do |t|
+    t.string   "name"
+    t.integer  "children_count",      :default => 0, :null => false
+    t.integer  "grandchildren_count", :default => 0, :null => false
+    t.integer  "lock_version",        :default => 0, :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "locking_children", :force => true do |t|
+    t.integer  "locking_parent_id"
+    t.integer  "grandchildren_count", :default => 0, :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "locking_grandchildren", :force => true do |t|
+    t.integer  "locking_child_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 end


### PR DESCRIPTION
## Problem

Since v3.12.1 (#425), counter_culture uses hash-based `update_all` for Arel compatibility. Rails auto-increments `lock_version` when `update_all` receives a Hash and the model has optimistic locking - see   [ActiveRecord::Relation#update_all](https://github.com/rails/rails/blob/v8.1.3/activerecord/lib/active_record/relation.rb#L615-L621).

Before v3.12.1 counter_culture used string-based `update_all` which Rails does not modify.

So now counter updates silently bump `lock_version` in the DB while the in-memory object keeps the old value. If the parent also has `belongs_to ... touch: true` children, the next `touch` finds a stale `lock_version` and raises `ActiveRecord::StaleObjectError`.

## Fix

Include `lock_version = lock_version` (no-op) in the `arel_updates` hash before calling `update_all`. Rails sees the key is already there and skips the auto-increment.

Counter updates are atomic SQL (`SET col = col + 1`) - they do not need optimistic locking.

Applied to both immediate and aggregate update paths.