### PR TITLE
Update multi-level counter cache in memory

### DIFF
--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -410,9 +410,7 @@ module CounterCulture
 
     # update associated object counter attribute
     def assign_to_associated_object(obj, relation, change_counter_column, operator, delta_magnitude)
-      association_name = relation_reflect(relation).name
-
-      association_object = association_object_for_assign(obj, association_name)
+      association_object = association_object_for_assign(obj, relation)
       return if association_object.blank? || association_object.frozen?
 
       association_object.assign_attributes(
@@ -422,21 +420,22 @@ module CounterCulture
       association_object_clear_change(association_object, change_counter_column)
     end
 
-    def association_object_for_assign(obj, association_name)
-      if obj.class.reflect_on_all_associations.
-          find { |assoc| assoc.name.to_sym == association_name.to_sym }.
-          blank?
-        # This means that this isn't defined as an association; either it
-        # doesn't exist at all, or it uses delegate. In either case, we can't
-        # update the count this way.
-        return
-      end
-      if !obj.association(association_name).loaded?
-        # If the association isn't loaded, no need to update the count
-        return
+    def association_object_for_assign(obj, relation)
+      relation = relation.is_a?(Enumerable) ? relation.dup : [relation]
+
+      while !obj.nil? && relation.size > 0
+        cur_relation = relation.shift
+        return nil if obj.class.reflect_on_association(cur_relation).nil?
+
+        if !obj.association(cur_relation).loaded?
+          # If the association isn't loaded, no need to update the count
+          return nil
+        end
+
+        obj = obj.public_send(cur_relation)
       end
 
-      obj.public_send(association_name)
+      obj
     end
 
     def association_object_clear_change(association_object, change_counter_column)

--- a/spec/counter_culture/basic_counter_cache_spec.rb
+++ b/spec/counter_culture/basic_counter_cache_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe "CounterCulture basic counter cache" do
     expect(product.reviews_count).to eq(1)
   end
 
+  it "increments multi-level counter cache on create without reload" do
+    industry = Industry.create
+    company = Company.create industry: industry
+    user = User.create manages_company: company
+
+    expect(company.reviews_count).to eq(0)
+    expect(industry.reviews_count).to eq(0)
+
+    user.reviews.create
+
+    expect(company.reviews_count).to eq(1)
+    expect(industry.reviews_count).to eq(1)
+
+    # NOTE: check if counters from the DB equal to the cached
+    company.reload
+    industry.reload
+
+    expect(company.reviews_count).to eq(1)
+    expect(industry.reviews_count).to eq(1)
+  end
+
   it "updates counter caches on change belongs_to association" do
     simple_main1 = SimpleMain.create
     simple_main2 = SimpleMain.create
@@ -218,6 +239,38 @@ RSpec.describe "CounterCulture basic counter cache" do
     expect(user.reviews_count).to eq(0)
     expect(user.review_approvals_count).to eq(0)
     expect(product.reviews_count).to eq(0)
+  end
+
+  it "decrements multi-level counter cache on destroy without reload" do
+    industry = Industry.create
+    company = Company.create industry: industry
+    user = User.create manages_company: company
+
+    expect(company.reviews_count).to eq(0)
+    expect(industry.reviews_count).to eq(0)
+
+    review = user.reviews.create
+
+    expect(company.reviews_count).to eq(1)
+    expect(industry.reviews_count).to eq(1)
+
+    review.destroy
+
+    expect(company.reviews_count).to eq(0)
+    expect(industry.reviews_count).to eq(0)
+
+    # this does not decrement counter cache
+    review.destroy
+
+    expect(company.reviews_count).to eq(0)
+    expect(industry.reviews_count).to eq(0)
+
+    # NOTE: check if counters from the DB equal to the cached
+    company.reload
+    industry.reload
+
+    expect(company.reviews_count).to eq(0)
+    expect(industry.reviews_count).to eq(0)
   end
 
   it "updates counter cache on update" do


### PR DESCRIPTION
Hello,

This PR is a fix for #431.

Currently, updating a multi-level counter cache in memory doesn't work because `#association_object_for_assign` cannot access the leaf association from the root object.

I've modified the method to traverse the chain of associations and return the leaf object that holds the in-memory counter cache (unless we encounter `nil` or an un-loaded association along the way).