### PR TITLE
Use ActiveRecord.after_all_transactions_commit on Rails 7.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+New features:
+  - Use the built-in `ActiveRecord.after_all_transactions_commit` API for `execute_after_commit` on Rails 7.2+, so the `after_commit_action` gem is no longer required on modern Rails. Older Rails versions keep using the gem as before.
+
 ## 3.13.3 (June 25, 2026)
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Another option is to simply defer the update of counter caches to outside of the
 ```ruby
   counter_culture :category, execute_after_commit: true
 ```
-[NOTE] You need to manually specify the `after_commit_action` as dependency in the Gemfile to use this feature
+[NOTE] On Rails 7.2 and newer this uses the built-in `ActiveRecord.after_all_transactions_commit` API and requires no extra dependencies. On older Rails versions you need to manually specify the `after_commit_action` gem as a dependency in your Gemfile to use this feature:
 ```ruby
 ...
 gem "after_commit_action"

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -21,7 +21,10 @@ module CounterCulture
       @execute_after_commit = options.fetch(:execute_after_commit, false)
       @include_soft_deleted = options.fetch(:include_soft_deleted, false)
 
-      if @execute_after_commit
+      # Rails 7.2+ ships `ActiveRecord.after_all_transactions_commit`, which
+      # does everything we need the `after_commit_action` gem for. Only fall
+      # back to the gem on older Rails versions.
+      if @execute_after_commit && !ActiveRecord.respond_to?(:after_all_transactions_commit)
         begin
           require 'after_commit_action'
         rescue LoadError
@@ -390,7 +393,11 @@ module CounterCulture
       execute_after_commit = @execute_after_commit.is_a?(Proc) ? @execute_after_commit.call : @execute_after_commit
 
       if execute_after_commit
-        obj.execute_after_commit(&block)
+        if ActiveRecord.respond_to?(:after_all_transactions_commit)
+          ActiveRecord.after_all_transactions_commit(&block)
+        else
+          obj.execute_after_commit(&block)
+        end
       else
         block.call
       end

--- a/spec/counter_culture/basic_counter_cache_spec.rb
+++ b/spec/counter_culture/basic_counter_cache_spec.rb
@@ -541,4 +541,21 @@ RSpec.describe "CounterCulture basic counter cache" do
     expect(subcateg2.posts_after_commit_count).to eq(1)
     expect(subcateg2.posts_dynamic_commit_count).to eq(1)
   end
+
+  context "on Rails 7.2+ (ActiveRecord.after_all_transactions_commit available)",
+    if: ActiveRecord.respond_to?(:after_all_transactions_commit) do
+    it "defers the update through ActiveRecord.after_all_transactions_commit" do
+      subcateg = Subcateg.create!
+
+      expect(ActiveRecord).to receive(:after_all_transactions_commit).at_least(:once).and_call_original
+
+      Post.create!(subcateg: subcateg)
+
+      expect(subcateg.reload.posts_after_commit_count).to eq(1)
+    end
+
+    it "does not mix the after_commit_action gem into the model" do
+      expect(Post.ancestors.map(&:to_s)).not_to include("AfterCommitAction")
+    end
+  end
 end


### PR DESCRIPTION
## What

`execute_after_commit` currently always depends on the [`after_commit_action`](https://github.com/comboy/after_commit_action) gem to defer counter cache updates until after the surrounding transaction commits. Rails 7.2 introduced [`ActiveRecord.after_all_transactions_commit`](https://github.com/rails/rails/pull/51474), which does exactly the same thing natively.

This PR prefers the built-in API when it's available, so on Rails 7.2+ `execute_after_commit` no longer requires any extra dependency. On older Rails versions nothing changes — it keeps using `after_commit_action` exactly as before.

## Why

This is the recurring request in #263 and #120 (avoiding deadlocks by moving counter updates after commit). The original reason for pulling in a separate gem was that Rails had no public hook for "run this after the outermost transaction commits." Rails 7.2 now ships one, so on modern Rails the dependency is redundant.

As a small bonus, `after_all_transactions_commit` runs the block **immediately** when there is no open transaction, whereas the per-record `after_commit` hook would otherwise never fire in that case.

## Changes

- `Counter#initialize`: only `require 'after_commit_action'` / `include AfterCommitAction` when `ActiveRecord` does **not** respond to `after_all_transactions_commit` (i.e. Rails < 7.2).
- `Counter#execute_now_or_after_commit`: dispatch through `ActiveRecord.after_all_transactions_commit` when available, falling back to `obj.execute_after_commit`.
- Specs: added a context (guarded by `ActiveRecord.respond_to?(:after_all_transactions_commit)`) asserting the update is routed through the native API and that the `after_commit_action` module is not mixed into the model on modern Rails.
- README + CHANGELOG updated.

## Testing

Full suite passes on Rails 8.1 / sqlite3 (`218 examples, 0 failures`, 2 PostgreSQL-only pending). The existing `execute_after_commit` behavior specs already cover the deferral semantics and now exercise the native path on Rails 7.2+; the gem fallback path remains covered by the older-Rails entries in the CI matrix.