### PR TITLE
Use ActiveRecord.after_all_transactions_commit on Rails 7.2+ (revised #435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+New features:
+  - Use the built-in `ActiveRecord.after_all_transactions_commit` API for `execute_after_commit` on Rails 7.2+, so the `after_commit_action` gem is no longer required on modern Rails. Older Rails versions keep using the gem as before.
+
 ## 3.13.3 (June 25, 2026)
 
 Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 New features:
   - Use the built-in `ActiveRecord.after_all_transactions_commit` API for `execute_after_commit` on Rails 7.2+, so the `after_commit_action` gem is no longer required on modern Rails. Older Rails versions keep using the gem as before.
 
+Changes:
+  - On Rails 7.2+, counter_culture no longer mixes the `after_commit_action` gem's `AfterCommitAction` module into models that use `execute_after_commit`. If your own code called the `execute_after_commit` instance method on those models (relying on counter_culture to make it available), add the `after_commit_action` gem and `include AfterCommitAction` yourself.
+
 ## 3.13.3 (June 25, 2026)
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Another option is to simply defer the update of counter caches to outside of the
 ```ruby
   counter_culture :category, execute_after_commit: true
 ```
-[NOTE] You need to manually specify the `after_commit_action` as dependency in the Gemfile to use this feature
+[NOTE] On Rails 7.2 and newer this uses the built-in `ActiveRecord.after_all_transactions_commit` API and requires no extra dependencies. On older Rails versions you need to manually specify the `after_commit_action` gem as a dependency in your Gemfile to use this feature:
 ```ruby
 ...
 gem "after_commit_action"

--- a/lib/counter_culture/configuration.rb
+++ b/lib/counter_culture/configuration.rb
@@ -15,6 +15,13 @@ module CounterCulture
     Gem::Requirement.new('>= 7.2.0').satisfied_by?(ActiveRecord.version)
   end
 
+  # Rails 7.2+ ships `ActiveRecord.after_all_transactions_commit`, which lets
+  # `execute_after_commit` defer counter updates natively instead of relying on
+  # the `after_commit_action` gem.
+  def self.supports_native_after_commit?
+    Gem::Requirement.new('>= 7.2.0').satisfied_by?(ActiveRecord.version)
+  end
+
   class Configuration
     attr_reader :use_read_replica
 

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -21,7 +21,10 @@ module CounterCulture
       @execute_after_commit = options.fetch(:execute_after_commit, false)
       @include_soft_deleted = options.fetch(:include_soft_deleted, false)
 
-      if @execute_after_commit
+      # Rails 7.2+ ships `ActiveRecord.after_all_transactions_commit`, which
+      # does everything we need the `after_commit_action` gem for. Only fall
+      # back to the gem on older Rails versions.
+      if @execute_after_commit && !ActiveRecord.respond_to?(:after_all_transactions_commit)
         begin
           require 'after_commit_action'
         rescue LoadError
@@ -390,7 +393,11 @@ module CounterCulture
       execute_after_commit = @execute_after_commit.is_a?(Proc) ? @execute_after_commit.call : @execute_after_commit
 
       if execute_after_commit
-        obj.execute_after_commit(&block)
+        if ActiveRecord.respond_to?(:after_all_transactions_commit)
+          ActiveRecord.after_all_transactions_commit(&block)
+        else
+          obj.execute_after_commit(&block)
+        end
       else
         block.call
       end

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -24,7 +24,7 @@ module CounterCulture
       # Rails 7.2+ ships `ActiveRecord.after_all_transactions_commit`, which
       # does everything we need the `after_commit_action` gem for. Only fall
       # back to the gem on older Rails versions.
-      if @execute_after_commit && !ActiveRecord.respond_to?(:after_all_transactions_commit)
+      if @execute_after_commit && !CounterCulture.supports_native_after_commit?
         begin
           require 'after_commit_action'
         rescue LoadError
@@ -393,7 +393,7 @@ module CounterCulture
       execute_after_commit = @execute_after_commit.is_a?(Proc) ? @execute_after_commit.call : @execute_after_commit
 
       if execute_after_commit
-        if ActiveRecord.respond_to?(:after_all_transactions_commit)
+        if CounterCulture.supports_native_after_commit?
           ActiveRecord.after_all_transactions_commit(&block)
         else
           obj.execute_after_commit(&block)

--- a/lib/counter_culture/counter.rb
+++ b/lib/counter_culture/counter.rb
@@ -394,6 +394,13 @@ module CounterCulture
 
       if execute_after_commit
         if CounterCulture.supports_native_after_commit?
+          # NOTE: `after_all_transactions_commit` waits for *every* open
+          # transaction across *all* database connections and skips the block if
+          # any of them roll back, whereas `after_commit_action` tied the block to
+          # this record's own connection only. The two are equivalent for a
+          # single database; they differ only when a record is saved inside
+          # transactions that span multiple databases (which Rails itself
+          # discourages).
           ActiveRecord.after_all_transactions_commit(&block)
         else
           obj.execute_after_commit(&block)

--- a/spec/counter_culture/basic_counter_cache_spec.rb
+++ b/spec/counter_culture/basic_counter_cache_spec.rb
@@ -541,4 +541,21 @@ RSpec.describe "CounterCulture basic counter cache" do
     expect(subcateg2.posts_after_commit_count).to eq(1)
     expect(subcateg2.posts_dynamic_commit_count).to eq(1)
   end
+
+  context "on Rails 7.2+ (ActiveRecord.after_all_transactions_commit available)",
+    if: ActiveRecord.respond_to?(:after_all_transactions_commit) do
+    it "defers the update through ActiveRecord.after_all_transactions_commit" do
+      subcateg = Subcateg.create!
+
+      expect(ActiveRecord).to receive(:after_all_transactions_commit).at_least(:once).and_call_original
+
+      Post.create!(subcateg: subcateg)
+
+      expect(subcateg.reload.posts_after_commit_count).to eq(1)
+    end
+
+    it "does not mix the after_commit_action gem into the model" do
+      expect(Post.ancestors.map(&:to_s)).not_to include("AfterCommitAction")
+    end
+  end
 end

--- a/spec/counter_culture/basic_counter_cache_spec.rb
+++ b/spec/counter_culture/basic_counter_cache_spec.rb
@@ -542,8 +542,11 @@ RSpec.describe "CounterCulture basic counter cache" do
     expect(subcateg2.posts_dynamic_commit_count).to eq(1)
   end
 
-  context "on Rails 7.2+ (ActiveRecord.after_all_transactions_commit available)",
-    if: ActiveRecord.respond_to?(:after_all_transactions_commit) do
+  context "on Rails 7.2+ (ActiveRecord.after_all_transactions_commit available)" do
+    before do
+      skip("ActiveRecord.after_all_transactions_commit is only available on Rails 7.2+") unless CounterCulture.supports_native_after_commit?
+    end
+
     it "routes deferred updates through ActiveRecord.after_all_transactions_commit" do
       subcateg = Subcateg.create!
 

--- a/spec/counter_culture/basic_counter_cache_spec.rb
+++ b/spec/counter_culture/basic_counter_cache_spec.rb
@@ -544,13 +544,30 @@ RSpec.describe "CounterCulture basic counter cache" do
 
   context "on Rails 7.2+ (ActiveRecord.after_all_transactions_commit available)",
     if: ActiveRecord.respond_to?(:after_all_transactions_commit) do
-    it "defers the update through ActiveRecord.after_all_transactions_commit" do
+    it "routes deferred updates through ActiveRecord.after_all_transactions_commit" do
       subcateg = Subcateg.create!
 
+      # Post defers more than one counter on create, so just assert the native
+      # API is used rather than the after_commit_action gem (the exact dispatch
+      # count varies with papertrail tracking).
       expect(ActiveRecord).to receive(:after_all_transactions_commit).at_least(:once).and_call_original
 
       Post.create!(subcateg: subcateg)
 
+      expect(subcateg.reload.posts_after_commit_count).to eq(1)
+    end
+
+    it "defers the update until the surrounding transaction commits" do
+      subcateg = Subcateg.create!
+
+      Post.transaction do
+        Post.create!(subcateg: subcateg)
+
+        # Still inside the transaction: the deferred update must not have run yet.
+        expect(subcateg.reload.posts_after_commit_count).to eq(0)
+      end
+
+      # Once the transaction commits the deferred update runs.
       expect(subcateg.reload.posts_after_commit_count).to eq(1)
     end
 


### PR DESCRIPTION
This is a copy of #435 by @rainerborene with the review feedback addressed. The original commit is preserved; the follow-up commits address points raised in review.

## Original change (from #435)

On Rails 7.2+, `execute_after_commit` now defers counter updates through the built-in `ActiveRecord.after_all_transactions_commit` API instead of the `after_commit_action` gem, so the gem is no longer required on modern Rails. Older Rails versions keep using the gem unchanged.

## Review feedback addressed

- **Extract Rails 7.2 detection into a shared predicate** — the native-vs-gem decision checked `ActiveRecord.respond_to?(:after_all_transactions_commit)` inline in two places; both now use a single `CounterCulture.supports_native_after_commit?` predicate, mirroring the existing `supports_composite_keys?` gate and the repo's version-gating idiom.
- **Strengthen the native after-commit specs to assert deferral** — the original example only checked that the method was called and the final count was right (guaranteed by `and_call_original` regardless of correct deferral). Split into one example confirming updates route through the native API and one that proves the deferral semantics by asserting the counter is unchanged inside an open transaction and only updated after commit.
- **Use an explicit skip for the gated specs** — replaced the `if:` example-group conditional with the suite's `skip("...") unless <condition>` convention (as in `papertrail_spec.rb` and the composite-key specs).
- **Document that `AfterCommitAction` is no longer mixed in on Rails 7.2+** — changelog note for anyone who relied on counter_culture exposing the `execute_after_commit` instance method as a side effect.
- **Document the multi-database semantics** — `after_all_transactions_commit` waits for every open transaction across all connections and drops the block if any rolls back, unlike the old per-connection `after_commit_action` path; noted at the call site (equivalent for single-database apps).

Full suite passes on Rails 8.1 / sqlite3 (219 examples, 0 failures, 2 PostgreSQL-only pending).

Supersedes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018w5yayAZqjkr3HAiMPLviT